### PR TITLE
Issue #6: Rename lambda function for BIG terraform limit error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `bignbit` Issue #2: [Create github action pipeline to build artifacts](https://github.com/podaac/bignbit/issues/2),
 - `bignbit` Issue #3: [Update terraform mock deployment of cumulus module to services accounts](https://github.com/podaac/bignbit/issues/3),
 
-
+### Changed
+- `bignbit` Issue #6: [BIG terraform failing in SWOT venues due to long lambda name](https://github.com/podaac/bignbit/issues/6),
 
 
 [unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...HEAD

--- a/bignbit/copy_harmony_results_to_s3.py
+++ b/bignbit/copy_harmony_results_to_s3.py
@@ -9,7 +9,7 @@ from cumulus_process import Process, s3
 
 from bignbit import utils
 
-CUMULUS_LOGGER = CumulusLogger('copy_harmony_results_to_s3')
+CUMULUS_LOGGER = CumulusLogger('copy_harmony_output_to_s3')
 
 
 class CMA(Process):

--- a/examples/cumulus-tf/step.tf
+++ b/examples/cumulus-tf/step.tf
@@ -298,7 +298,7 @@ resource "aws_sfn_state_machine" "sfn_state_machine" {
                },
                "Copy Harmony Results to S3":{
                   "Type":"Task",
-                  "Resource":"${module.bignbit_module.copy_harmony_results_to_s3_arn}",
+                  "Resource":"${module.bignbit_module.copy_harmony_output_to_s3_arn}",
                   "Parameters":{
                      "cma":{
                         "event.$":"$",

--- a/terraform/lambda_functions.tf
+++ b/terraform/lambda_functions.tf
@@ -282,7 +282,7 @@ resource "aws_lambda_function" "get_harmony_job_status" {
   tags = var.default_tags
 }
 
-resource "aws_lambda_function" "copy_harmony_results_to_s3" {
+resource "aws_lambda_function" "copy_harmony_output_to_s3" {
   depends_on = [
     null_resource.upload_ecr_image
   ]
@@ -290,9 +290,9 @@ resource "aws_lambda_function" "copy_harmony_results_to_s3" {
   package_type = "Image"
   image_uri    = "${aws_ecr_repository.lambda-image-repo.repository_url}:${local.ecr_image_tag}"
   image_config {
-    command = ["bignbit.copy_harmony_results_to_s3.lambda_handler"]
+    command = ["bignbit.copy_harmony_output_to_s3.lambda_handler"]
   }
-  function_name = "${local.lambda_resources_name}-copy_harmony_results_to_s3-lambda"
+  function_name = "${local.lambda_resources_name}-copy_harmony_output_to_s3-lambda"
   role          = var.lambda_role.arn
   timeout       = 30
   memory_size   = 256
@@ -350,7 +350,7 @@ resource "aws_lambda_function" "apply_opera_treatment" {
 
 
 resource "aws_lambda_function" "build_image_sets" {
-  
+
   depends_on = [
     null_resource.upload_ecr_image
   ]
@@ -360,7 +360,7 @@ resource "aws_lambda_function" "build_image_sets" {
   image_config {
     command = ["bignbit.build_image_sets.lambda_handler"]
   }
-  
+
   function_name    = local.build_image_sets_function_name
   role             = var.lambda_role.arn
   timeout          = 15

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -31,8 +31,8 @@ output "get_harmony_job_status_arn" {
   value = aws_lambda_function.get_harmony_job_status.arn
 }
 
-output "copy_harmony_results_to_s3_arn"{
-  value = aws_lambda_function.copy_harmony_results_to_s3.arn
+output "copy_harmony_output_to_s3_arn"{
+  value = aws_lambda_function.copy_harmony_output_to_s3.arn
 }
 
 output "apply_opera_treatment_arn"{


### PR DESCRIPTION
Github Issue: #6 

### Description

BIG terraform failing in SWOT venues due to long lambda name

- Rename lambda function for BIG terraform limit error fix

### Overview of work done

Rename lambda func: copy_harmony_results_to_s3 --> copy_harmony_output_to_s3

### Overview of verification done

CI

### Overview of integration done

Actions: SIT

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_