### PR TITLE
feature: convertToPNG --> sendToHarmony

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+
+### Changed
+- [issues/15](https://github.com/podaac/bignbit/issues/15): Change 'convertToPNG' choice to a generic send to harmony choice
+
 ## [0.1.1]
 
 ### Added 
@@ -17,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [issues/10](https://github.com/podaac/bignbit/issues/10): Move combined big and pobit state machine into terraform module
 - [issues/6](https://github.com/podaac/bignbit/issues/6): BIG terraform failing in SWOT venues due to long lambda name
-- [issues/15](https://github.com/podaac/bignbit/issues/15): Change 'convertToPNG' choice to a generic send to harmony choice
 
 
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/0.1.1...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `bignbit` Issue #10: [Move combined big and pobit state machine into terraform module](https://github.com/podaac/bignbit/issues/10),
 - `bignbit` Issue #6: [BIG terraform failing in SWOT venues due to long lambda name](https://github.com/podaac/bignbit/issues/6),
+- `bignbit` Issue #15: [Change 'convertToPNG' choice to a generic send to harmony choice](https://github.com/podaac/bignbit/issues/15),
 
 
 [unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...HEAD

--- a/terraform/state_machine_definition.tpl
+++ b/terraform/state_machine_definition.tpl
@@ -59,23 +59,23 @@
           "BackoffRate":2
         }
       ],
-      "Next":"Convert to PNG?"
+      "Next":"Send to Harmony?"
     },
-    "Convert to PNG?":{
+    "Send to Harmony?":{
       "Type":"Choice",
       "Choices":[
         {
           "And":[
             {
-              "Variable":"$.payload.datasetConfigurationForBIG.config.convertToPNG",
+              "Variable":"$.payload.datasetConfigurationForBIG.config.sendToHarmony",
               "IsPresent":true
             },
             {
-              "Variable":"$.payload.datasetConfigurationForBIG.config.convertToPNG",
+              "Variable":"$.payload.datasetConfigurationForBIG.config.sendToHarmony",
               "BooleanEquals":true
             }
           ],
-          "Comment":"If convertToPNG is true",
+          "Comment":"If sendToHarmony is true",
           "Next":"Get Collection Concept Id"
         }
       ],

--- a/tests/sample_messages/generate_image_metadata/cma.uat.input.OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.json
+++ b/tests/sample_messages/generate_image_metadata/cma.uat.input.OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.json
@@ -526,7 +526,7 @@
         ],
         "datasetConfigurationForBIG": {
           "config": {
-            "convertToPNG": "false",
+            "sendToHarmony": "false",
             "imageFilenameRegex": ".*BROWSE.tif",
             "imgVariables": [
               {


### PR DESCRIPTION
Github Issue: #15 

### Description

Change State_Machine (boolean Choice) `convertToPNG` --> `sendToHarmony` to accommodate OPERA product's use of BIGnBIT Workflow, and improve dataset config identification for OPERA with `sendToHarmony`. 

### Overview of work done

Changed State_Machine step `convertToPNG` --> `sendToHarmony` (true/false)

### Overview of verification done

Ran in SIT bignbit (browseimageworkflow)

* **Test data**: `OPERA_L3_DSWX-S1_V1`

```
"sendToHarmony": false,
```


<img width="498" alt="Screenshot 2024-04-25 at 3 54 06 PM" src="https://github.com/podaac/bignbit/assets/35245966/29c6e513-8d44-4d7c-94fc-c1c54c581d6f">

----------------------------


* **Test data**: `MUR-JPL-L4-GLOB-v4.1`

```
"sendToHarmony": true,
```
<img width="1036" alt="Screenshot 2024-04-25 at 3 55 48 PM" src="https://github.com/podaac/bignbit/assets/35245966/e8efed0f-e6ec-4030-9e87-7812bd93fd9e">

_State Test:_
```
{
    "nextState": "Get Collection Concept Id",
    "output": ...
    "status": "SUCCEEDED"
},

```

<img width="762" alt="Screenshot 2024-04-25 at 3 58 49 PM" src="https://github.com/podaac/bignbit/assets/35245966/734e601b-ba54-4901-add9-533938b7ca6f">


### Overview of integration done

```
mock pytest tests 
```


## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_