### PR TITLE
Update - Pipeline Artifact Zip

### DIFF
--- a/.github/workflows/cicd-pipeline.yml
+++ b/.github/workflows/cicd-pipeline.yml
@@ -184,7 +184,7 @@ jobs:
           mkdir -p build/${{ steps.poetry-build.outputs.tf_module_artifact_name }}
           cp terraform/* build/${{ steps.poetry-build.outputs.tf_module_artifact_name }}/
           cd build
-          zip ${{ steps.poetry-build.outputs.tf_module_artifact_name }}.zip ${{ steps.poetry-build.outputs.tf_module_artifact_name }}/* -r
+          zip ${{ steps.poetry-build.outputs.tf_module_artifact_name }}.zip ${{ steps.poetry-build.outputs.tf_module_artifact_name }}/* -r -j
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.poetry-build.outputs.tf_module_artifact_name }}


### PR DESCRIPTION
### Description

CICD Artifact ZIP

bignbit - `release/0.1.1` module delivery fix

### Overview of work done

zip terraform module at `.tf ` files level.

