### PR TITLE
Release/0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [0.2.1]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- [issues/50](https://github.com/podaac/bignbit/issues/50): Fixed bug where `count` is unsupported for bignbit by inheriting the AWS provider config from the root module
+### Security
+
 ## [0.2.0]
 ### Added
 - [issues/40](https://github.com/podaac/bignbit/issues/40): New message attribute `response_topic_arn` will be added to every message sent to GIBS

--- a/examples/cumulus-tf/browse_image_workflow.tf
+++ b/examples/cumulus-tf/browse_image_workflow.tf
@@ -5,6 +5,8 @@ locals {
 module "bignbit_module" {
     source = "../../terraform"
 
+    count = 1
+
     stage = var.bignbit_stage
     prefix = var.prefix
 

--- a/examples/cumulus-tf/browse_image_workflow.tf
+++ b/examples/cumulus-tf/browse_image_workflow.tf
@@ -1,39 +1,53 @@
 locals {
-    bignbit_appname = "bignbit"
+  bignbit_appname = "bignbit"
+}
+
+provider "aws" {
+  alias = "bignbit-aws"
+  default_tags {
+    tags = merge(local.default_tags, {
+      application = local.bignbit_appname,
+      Version     = var.app_version,
+    })
+  }
 }
 
 module "bignbit_module" {
-    source = "../../terraform"
+  source = "../../terraform"
+  providers = {
+    aws = aws.bignbit-aws
+  }
 
-    count = 1
+  count = 1
 
-    stage = var.bignbit_stage
-    prefix = var.prefix
+  stage  = var.bignbit_stage
+  prefix = var.prefix
 
-    data_buckets = [aws_s3_bucket.protected.id, aws_s3_bucket.public.id, aws_s3_bucket.private.id]
+  data_buckets = [aws_s3_bucket.protected.id, aws_s3_bucket.public.id, aws_s3_bucket.private.id]
 
-    config_bucket = aws_s3_bucket.internal.bucket
-    config_dir = "big-config"
+  config_bucket = aws_s3_bucket.internal.bucket
+  config_dir    = "big-config"
 
-    bignbit_audit_bucket = aws_s3_bucket.internal.bucket
+  bignbit_audit_bucket = aws_s3_bucket.internal.bucket
+  bignbit_audit_path   = "bignbit-cnm-output"
 
-    gibs_region = var.gibs_region == "mocked" ? "us-west-2" : var.gibs_region
-    gibs_queue_name = var.gibs_queue_name == "mocked" ? aws_sqs_queue.gitc_input_queue[0].name : var.gibs_queue_name
-    gibs_account_id = var.gibs_account_id == "mocked" ? local.account_id : var.gibs_account_id
+  gibs_region     = var.gibs_region == "mocked" ? "us-west-2" : var.gibs_region
+  gibs_queue_name = var.gibs_queue_name == "mocked" ? aws_sqs_queue.gitc_input_queue[0].name : var.gibs_queue_name
+  gibs_account_id = var.gibs_account_id == "mocked" ? local.account_id : var.gibs_account_id
 
-    edl_user_ssm = var.edl_user
-    edl_pass_ssm = var.edl_pass
+  edl_user_ssm = var.edl_user
+  edl_pass_ssm = var.edl_pass
 
-    permissions_boundary_arn = var.permissions_boundary_arn
-    security_group_ids = []
-    subnet_ids = []
+  permissions_boundary_arn = var.permissions_boundary_arn
+  security_group_ids = []
+  subnet_ids = []
 
-    app_name = local.bignbit_appname
-    default_tags = merge(local.default_tags, {
-        application = local.bignbit_appname,
-        Version = var.app_version
-    })
-    lambda_container_image_uri = var.lambda_container_image_uri
+  app_name = local.bignbit_appname
+  default_tags = merge(local.default_tags, {
+    application = local.bignbit_appname,
+    Version     = var.app_version
+  })
+  lambda_container_image_uri = var.lambda_container_image_uri
 }
 
 /*
@@ -57,5 +71,5 @@ resource "aws_sfn_state_machine" "sfn_state_machine" {
   name     = "${local.ec2_resources_name}-BrowseImageWorkflow"
   role_arn = aws_iam_role.step.arn
 
-  definition = module.bignbit_module.workflow_definition
+  definition = module.bignbit_module[0].workflow_definition
 }

--- a/examples/cumulus-tf/main.tf
+++ b/examples/cumulus-tf/main.tf
@@ -39,7 +39,6 @@ locals {
   default_tags = {
     team: "TVA",
     application: local.ec2_resources_name,
-    Environment = var.bignbit_stage
-    Version = var.app_version
+    Environment = var.bignbit_stage,
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bignbit"
-version = "0.2.0"
+version = "0.2.1rc0"
 description = "Browse image generation and transfer"
 authors = ["PO.DAAC <podaac@jpl.nasa.gov>"]
 license = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bignbit"
-version = "0.2.1rc3"
+version = "0.2.1rc4"
 description = "Browse image generation and transfer"
 authors = ["PO.DAAC <podaac@jpl.nasa.gov>"]
 license = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bignbit"
-version = "0.2.1rc0"
+version = "0.2.1rc3"
 description = "Browse image generation and transfer"
 authors = ["PO.DAAC <podaac@jpl.nasa.gov>"]
 license = "Apache 2.0"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,18 +11,6 @@ terraform {
   }
 }
 
-provider "aws" {
-  region = "us-west-2"
-
-  ignore_tags {
-    key_prefixes = ["gsfc-ngap"]
-  }
-
-  default_tags {
-    tags = local.default_tags
-  }
-}
-
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 


### PR DESCRIPTION
# Release Notes

- Refactored module to inherit provider configuration from root module in order to support `count` on the bignbit module.

> [!NOTE]
> If bignbit was previously deployed without using `count` and `count` is added, most resources will need to be destroyed and recreated as they will transition from a single item to a list of 1 item. This will require extra care to be taken during deployment including potentially emptying both the ECR repository and the S3 staging bucket to allow for deletion. Alternatively it may be possible to `terraform import` the existing resources into the new plan but that was not tested.

# Test Results

Tested in services UAT by setting `count = 1` on the bignbit module and running `terraform apply`

# Changelog

## [0.2.1]
### Added
### Changed
### Deprecated
### Removed
### Fixed
- [issues/50](https://github.com/podaac/bignbit/issues/50): Fixed bug where `count` is unsupported for bignbit by inheriting the AWS provider config from the root module
### Security