### PR TITLE
Release/0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- [issues/54](https://github.com/podaac/bignbit/issues/54): Fixed bug where status was not being reported to Cumulus Dashboard by adding `cumulus_meta` back into the output CMA.
 ### Security
 
 ## [0.2.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- [issues/55](https://github.com/podaac/bignbit/issues/55): Harmony client changed from per request and instead will be cached as global variable and will not validate auth credentials on initialization.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [0.2.3]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## [0.2.2]
 ### Added
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
-- [issues/55](https://github.com/podaac/bignbit/issues/55): Harmony client changed from per request and instead will be cached as global variable and will not validate auth credentials on initialization.
 ### Deprecated
 ### Removed
 ### Fixed
-- [issues/54](https://github.com/podaac/bignbit/issues/54): Fixed bug where status was not being reported to Cumulus Dashboard by adding `cumulus_meta` back into the output CMA.
 ### Security
 
 ## [0.2.3]
 ### Added
 ### Changed
+- [issues/55](https://github.com/podaac/bignbit/issues/55): Harmony client changed from per request and instead will be cached as global variable and will not validate auth credentials on initialization.
 ### Deprecated
 ### Removed
 ### Fixed
+- [issues/54](https://github.com/podaac/bignbit/issues/54): Fixed bug where status was not being reported to Cumulus Dashboard by adding `cumulus_meta` back into the output CMA.
 ### Security
 
 ## [0.2.2]

--- a/bignbit/utils.py
+++ b/bignbit/utils.py
@@ -14,6 +14,8 @@ ED_USER = ED_PASS = None
 EDL_USER_TOKEN = {}
 HARMONY_CLIENT: Client or None = None
 
+HARMONY_SHOULD_VALIDATE_AUTH = os.environ.get('HARMONY_SHOULD_VALIDATE_AUTH', default='False').upper() == 'TRUE'
+
 
 def get_edl_creds() -> (str, str):
     """
@@ -278,7 +280,7 @@ def get_harmony_client(environment_str: str) -> harmony.Client:
         HARMONY_CLIENT = Client(
             env=harmony_environ,
             auth=get_edl_creds(),
-            should_validate_auth=False
+            should_validate_auth=HARMONY_SHOULD_VALIDATE_AUTH
         )
 
     return HARMONY_CLIENT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bignbit"
-version = "0.2.3rc4"
+version = "0.2.3rc5"
 description = "Browse image generation and transfer"
 authors = ["PO.DAAC <podaac@jpl.nasa.gov>"]
 license = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bignbit"
-version = "0.2.3rc0"
+version = "0.2.3rc1"
 description = "Browse image generation and transfer"
 authors = ["PO.DAAC <podaac@jpl.nasa.gov>"]
 license = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bignbit"
-version = "0.2.2"
+version = "0.2.3rc0"
 description = "Browse image generation and transfer"
 authors = ["PO.DAAC <podaac@jpl.nasa.gov>"]
 license = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bignbit"
-version = "0.2.3rc1"
+version = "0.2.3rc2"
 description = "Browse image generation and transfer"
 authors = ["PO.DAAC <podaac@jpl.nasa.gov>"]
 license = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bignbit"
-version = "0.2.3rc2"
+version = "0.2.3rc3"
 description = "Browse image generation and transfer"
 authors = ["PO.DAAC <podaac@jpl.nasa.gov>"]
 license = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bignbit"
-version = "0.2.3rc3"
+version = "0.2.3rc4"
 description = "Browse image generation and transfer"
 authors = ["PO.DAAC <podaac@jpl.nasa.gov>"]
 license = "Apache 2.0"

--- a/terraform/state_machine_definition.tpl
+++ b/terraform/state_machine_definition.tpl
@@ -435,6 +435,7 @@
       "Type":"Pass",
       "Next":"BuildImageSets",
       "Parameters":{
+        "cumulus_meta.$": "$.cumulus_meta",
         "meta": {
           "buckets.$": "$.meta.buckets",
           "cmr.$": "$.meta.cmr",

--- a/tests/sample_messages/cma.uat.workflow-input.20210115090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.json
+++ b/tests/sample_messages/cma.uat.workflow-input.20210115090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1.json
@@ -1,4 +1,5 @@
 {
+  "cumulus_meta": {},
   "meta": {
     "provider": {},
     "stack": {},

--- a/tests/sample_messages/cma.uat.workflow-input.OPERA_L3_DSWx-HLS_T55MDS_20250124T001834Z_20250128T131415Z_L8_30_v1.0.json
+++ b/tests/sample_messages/cma.uat.workflow-input.OPERA_L3_DSWx-HLS_T55MDS_20250124T001834Z_20250128T131415Z_L8_30_v1.0.json
@@ -1,4 +1,5 @@
 {
+  "cumulus_meta": {},
   "meta": {
     "provider": {},
     "stack": {},

--- a/tests/sample_messages/cma.uat.workflow-input.OPERA_L3_DSWx-S1_T45QYD_20241001T121219Z_20241206T065726Z_S1A_30_v1.0.json
+++ b/tests/sample_messages/cma.uat.workflow-input.OPERA_L3_DSWx-S1_T45QYD_20241001T121219Z_20241206T065726Z_S1A_30_v1.0.json
@@ -1,4 +1,5 @@
 {
+  "cumulus_meta": {},
   "meta": {
     "provider": {},
     "stack": {},


### PR DESCRIPTION
# Release Notes

- Following triage with the Harmony team it was discovered that bignbit should throttle requests to the Harmony API. This can be controlled via the [background queue throttle](https://nasa.github.io/cumulus/docs/data-cookbooks/throttling-queued-executions/) for bignbit. This limits how many browse image workflows can run concurrently and should be set to no more than 100 for this release.
- A new environment variable `HARMONY_SHOULD_VALIDATE_AUTH` controls whether or not Harmony clients used by the lambdas will validate EDL credentials on initialization.
- This release also fixes a bug that was causing the workflow execution status in the Cumulus Dashboard to get stuck in "Running" status.

# Test Results

Tested in services UAT and observed `cumulus_meta` is now present in the output CMA message from the step function execution. This should allow proper updating to the cumulus dashboard status but will need to be verified once installed in a cumulus environment.

Was able to successfully run 100 parallel executions in services UAT environment.

# Changelog

## [0.2.3]
### Added
### Changed
- [issues/55](https://github.com/podaac/bignbit/issues/55): Harmony client changed from per request and instead will be cached as global variable and will not validate auth credentials on initialization.
### Deprecated
### Removed
### Fixed
- [issues/54](https://github.com/podaac/bignbit/issues/54): Fixed bug where status was not being reported to Cumulus Dashboard by adding `cumulus_meta` back into the output CMA.
### Security