### PR TITLE
Fixed bug causing GIBS responses to fail processing in OPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- [issues/60](https://github.com/podaac/bignbit/issues/60): Fixed bug causing GIBS responses to fail processing in OPS due to a case-sensitive comparison of environment name.
 ### Security
 
 ## [0.2.3]

--- a/terraform/lambda_functions.tf
+++ b/terraform/lambda_functions.tf
@@ -443,7 +443,7 @@ resource "aws_lambda_function" "handle_gitc_response" {
       REGION                      = data.aws_region.current.name
       BIGNBIT_AUDIT_BUCKET_NAME   = var.bignbit_audit_bucket
       BIGNBIT_AUDIT_PATH_NAME     = var.bignbit_audit_path
-      CMR_ENVIRONMENT             = local.environment != "OPS" ? "UAT" : ""
+      CMR_ENVIRONMENT             = upper(local.environment) != "OPS" ? "UAT" : ""
       EDL_USER_SSM                = var.edl_user_ssm
       EDL_PASS_SSM                = var.edl_pass_ssm
     }


### PR DESCRIPTION
Github Issue: Closes #60

### Description

Bug was discovered in OPS that was setting `CMR_ENVIRONMENT` to `UAT` for the  `handle_gitc_response` lambda.

### Overview of work done

Fixed by comparing uppercase value of environment variable

### Overview of verification done

N/A

### Overview of integration done

N/A

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_