### PR TITLE
Get concept ID from the `cmrLink` attribute in CMA input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - [issues/60](https://github.com/podaac/bignbit/issues/60): Fixed bug causing GIBS responses to fail processing in OPS due to a case-sensitive comparison of environment name.
+- [issues/65](https://github.com/podaac/bignbit/issues/65): Fixed bug when input CMA message does not contain `cmrConceptId` by parsing the concept ID from the `cmrLink` instead.
 ### Security
 
 ## [0.2.3]

--- a/bignbit/get_granule_umm_json.py
+++ b/bignbit/get_granule_umm_json.py
@@ -35,7 +35,7 @@ class CMA(Process):
         try:
             cmr_concept_id = self.input['granules'][0]['cmrConceptId']
         except KeyError:
-            cmr_concept_id = urllib.parse.urlparse(self.input['granules'][0]['cmrLink']).path.rstrip('/').split('/')[-1]
+            cmr_concept_id = urllib.parse.urlparse(self.input['granules'][0]['cmrLink']).path.rstrip('/').split('/')[-1].split('.')[0]
 
         self.input['granule_umm_json'] = utils.get_umm_json(cmr_concept_id, cmr_environment)
         return self.input

--- a/bignbit/get_granule_umm_json.py
+++ b/bignbit/get_granule_umm_json.py
@@ -3,6 +3,7 @@ Simple CMA lambda that get a granule's umm-json document and ads it to the paylo
 """
 import logging
 import os
+import urllib.parse
 
 from cumulus_logger import CumulusLogger
 from cumulus_process import Process
@@ -31,7 +32,10 @@ class CMA(Process):
 
         """
         cmr_environment = self.config['cmr_environment']
-        cmr_concept_id = self.input['granules'][0]['cmrConceptId']
+        try:
+            cmr_concept_id = self.input['granules'][0]['cmrConceptId']
+        except KeyError:
+            cmr_concept_id = urllib.parse.urlparse(self.input['granules'][0]['cmrLink']).path.rstrip('/').split('/')[-1]
 
         self.input['granule_umm_json'] = utils.get_umm_json(cmr_concept_id, cmr_environment)
         return self.input


### PR DESCRIPTION
Github Issue: #65 

### Description

Fixed bug when input CMA message does not contain `cmrConceptId` by parsing the concept ID from the `cmrLink` instead.

### Overview of work done

Parse the url in `cmrLink` to extract the last element of the path and use that for cmr concept id if `cmrConceptId` does not exist in the input.

### Overview of verification done

Tested the one line of code in python console:

```
>>> urllib.parse.urlparse("https://cmr.uat.earthdata.nasa.gov/search/concepts/G1273138331-LPCLOUDSB.umm_json").path.rstrip('/').split('/')[-1].split('.')[0]

'G1273138331-LPCLOUDSB'

```

### Overview of integration done

N/A

## PR checklist:

* [x] Linted
* [ ] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_