### PR TITLE
Increased timeout of the handle_gitc_response lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- [issues/71](https://github.com/podaac/bignbit/issues/71): Increased timeout of the handle_gitc_response lambda function from 15 seconds to 45 seconds.
 - [issues/68](https://github.com/podaac/bignbit/issues/68): Fixed bug that was causing excessive size of output state object from the TransferImageSet map step.
 - [issues/60](https://github.com/podaac/bignbit/issues/60): Fixed bug causing GIBS responses to fail processing in OPS due to a case-sensitive comparison of environment name.
 - [issues/65](https://github.com/podaac/bignbit/issues/65): Fixed bug when input CMA message does not contain `cmrConceptId` by parsing the concept ID from the `cmrLink` instead.

--- a/terraform/lambda_functions.tf
+++ b/terraform/lambda_functions.tf
@@ -433,7 +433,7 @@ resource "aws_lambda_function" "handle_gitc_response" {
   }
   function_name = local.handle_gitc_response_function_name
   role          = aws_iam_role.bignbit_lambda_role.arn
-  timeout       = 15
+  timeout       = 45
   memory_size   = 128
 
   environment {


### PR DESCRIPTION
Github Issue: Closes #71 

### Description

Increased timeout of the handle_gitc_response lambda function from 15 seconds to 45 seconds.

### Overview of work done

Increased timeout of the handle_gitc_response lambda function from 15 seconds to 45 seconds.

### Overview of verification done

N/A

### Overview of integration done

N/A

## PR checklist:

* [x] Linted
* [N/A] Updated unit tests
* [x] Updated changelog
* [N/A] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_