### PR TITLE
Issues/59: Add option to override data day with a static value from DatasetConfiguration message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- [issues/59](https://github.com/podaac/bignbit/issues/59): A new pair of keywords (`dataDayStrategy` and `singleDayNumber`) have been added to the DatasetConfiguration for BIG to enable proper image metadata for annual products. These keywords allow a dataset to override the umm-g date info.
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The contents of the configuration file should be a valid json object with the fo
 | imgVariables               | list(object) | List of JSON objects with at least one attribute called `id` whose value is the name of a variable to generate an image for. `all` can be used in cases where the collection does not have variables or all variables in the collection should have images generated      |
 | height                     | int          | Controls the height of the output image from Harmony (see https://github.com/nasa/harmony-browse-image-generator?tab=readme-ov-file#dimensions--scale-sizes) |
 | width                      | int          | Controls the width of the output image from Harmony (see https://github.com/nasa/harmony-browse-image-generator?tab=readme-ov-file#dimensions--scale-sizes)  |
+| dataDayStrategy            | string       | [OPTIONAL] If this keyword is set to "single_day_of_year", bignbit will override the date from the granule metadata with the one specified in "singleDayNumber"  |
+| singleDayNumber            | string       | [OPTIONAL] If using the "dataDayStrategy" keyword, all granules in this dataset will use the day of year specified in this keyword. ex: "001" for January 1st  |
 
 A few example configurations can be found in the [podaac/bignbit-config](https://github.com/podaac/bignbit-config) repository. NOTE: some of the example configurations have other options specified (e.g. `variables`, `latVar`, `lonVar`, etc...) that are no longer supported by this module. The table above are the attributes that are still in use.
 

--- a/README.md
+++ b/README.md
@@ -203,11 +203,12 @@ _Visual representation of the bignbit step function state machine:_
 # Local Development
 ## MacOS
 
-1. Install miniconda (or conda) and [poetry](https://python-poetry.org/)
+1. Install miniconda (or conda) and [poetry](https://python-poetry.org/). On MacOS, you can `brew install miniconda` and `brew install poetry`.
 2. Run `conda env create -f conda-environment.yaml` to install GDAL
-3. Activate the bignbit conda environment `conda activate bignbit`
-4. Install python package and dependencies `poetry install`
-5. Verify tests pass `poetry run pytest tests/`
+3. **(For MacOS users)** If you have a MacOS system and use zsh, you will need to run `conda init zsh`, close your terminal, and re-open before activating the environment in the next step.
+4. Activate the bignbit conda environment `conda activate bignbit`
+5. Install python package and dependencies `poetry install`
+6. Verify tests pass `poetry run pytest tests/`
 
 > [!IMPORTANT] 
 > If developing on a `darwin_arm64` based mac, running terraform locally may result

--- a/bignbit/generate_image_metadata.py
+++ b/bignbit/generate_image_metadata.py
@@ -53,7 +53,7 @@ class CMA(Process):
             cma_file_list = [item for sublist in cma_file_list for item in sublist]
         granule_umm_json = self.input['granule_umm_json']
 
-        # TO DO: perhaps there is a more organized way of managing these 
+        # TO DO: perhaps there is a more organized way of managing these
         # dataset-level overrides?
         dataset_config = self.input['datasetConfigurationForBIG']['config']
         data_day_strat = dataset_config.get('dataDayStrategy')
@@ -101,11 +101,11 @@ def generate_metadata(cma_file_list: List[Dict], granule_umm_json: Dict, temp_di
         CUMULUS_LOGGER.info(f'Processing file {granule_filename}')
 
         if static_data_day is not None and (static_data_day < 1 or static_data_day > 366):
-                CUMULUS_LOGGER.warn(
-                    f"Specified data day override {static_data_day} is not logical"
-                    "as a day of year. Defaulting to doy 001."
-                )
-                static_data_day = 1
+            CUMULUS_LOGGER.warning(
+                f"Specified data day override {static_data_day} is not logical "
+                "as a day of year. Defaulting to doy 001."
+            )
+            static_data_day = 1
         # Get date information from umm-g, if static_data_day is None it will be ignored
         begin, mid, end, dataday = extract_granule_dates(granule_umm_json, static_data_day)
 
@@ -125,7 +125,7 @@ def generate_metadata(cma_file_list: List[Dict], granule_umm_json: Dict, temp_di
         except KeyError:
             # No partial id for this granule
             partial_id = None
-            CUMULUS_LOGGER.warn(f"No partial id found in metadata for {granule_filename}. Leaving partial id blank.")
+            CUMULUS_LOGGER.warning(f"No partial id found in metadata for {granule_filename}. Leaving partial id blank.")
 
         # Convert from CMA file dict to CNM file dict
         cnm_file_meta = transform_files_to_cnm_product_files(cma_file_meta, granule_type, granule_subtype, dataday)

--- a/bignbit/generate_image_metadata.py
+++ b/bignbit/generate_image_metadata.py
@@ -6,8 +6,8 @@ import os
 import pathlib
 import uuid
 import xml.etree.ElementTree as ET
-from datetime import datetime
-from typing import Dict, List
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
 
 from cumulus_logger import CumulusLogger
 from cumulus_process import Process
@@ -53,14 +53,25 @@ class CMA(Process):
             cma_file_list = [item for sublist in cma_file_list for item in sublist]
         granule_umm_json = self.input['granule_umm_json']
 
-        file_metadata_list = generate_metadata(cma_file_list, granule_umm_json, pathlib.Path(f"{self.path}"))
+        # TO DO: perhaps there is a more organized way of managing these 
+        # dataset-level overrides?
+        dataset_config = self.input['datasetConfigurationForBIG']['config']
+        data_day_strat = dataset_config.get('dataDayStrategy')
+        if data_day_strat is not None and data_day_strat == 'single_day_of_year':
+            static_data_day = dataset_config.get('singleDayNumber', 1)
+            # Will throw TypeError on bad configuration
+            static_data_day = int(static_data_day)
+        else:
+            static_data_day = None
+
+        file_metadata_list = generate_metadata(cma_file_list, granule_umm_json, pathlib.Path(f"{self.path}"), static_data_day)
         del self.input['granule_umm_json']
         del self.input['big']
         self.input['big'] = file_metadata_list
         return self.input
 
 
-def generate_metadata(cma_file_list: List[Dict], granule_umm_json: dict, temp_dir: pathlib.Path) -> List[Dict]:
+def generate_metadata(cma_file_list: List[Dict], granule_umm_json: Dict, temp_dir: pathlib.Path, static_data_day: Optional[int] = None) -> List[Dict]:
     """
     For each file in the list, create an ImageMetadata-v1.2 xml file and upload it to s3 in the same
     bucket and path as the image file.
@@ -75,6 +86,9 @@ def generate_metadata(cma_file_list: List[Dict], granule_umm_json: dict, temp_di
       umm-json document for the granule being processed
     temp_dir
       Temporary location to write xml file to prior to upload to s3
+    static_data_day
+      Optionally, the DatasetConfiguration can override the date metadata in the 
+      granule umm-json
 
     Returns
     -------
@@ -86,8 +100,14 @@ def generate_metadata(cma_file_list: List[Dict], granule_umm_json: dict, temp_di
         granule_filename = cma_file_meta['filename'] if 'filename' in cma_file_meta else cma_file_meta['fileName']
         CUMULUS_LOGGER.info(f'Processing file {granule_filename}')
 
-        # Get date information from umm-g
-        begin, mid, end, dataday = extract_granule_dates(granule_umm_json)
+        if static_data_day is not None and (static_data_day < 1 or static_data_day > 366):
+                CUMULUS_LOGGER.warn(
+                    f"Specified data day override {static_data_day} is not logical"
+                    "as a day of year. Defaulting to doy 001."
+                )
+                static_data_day = 1
+        # Get date information from umm-g, if static_data_day is None it will be ignored
+        begin, mid, end, dataday = extract_granule_dates(granule_umm_json, static_data_day)
 
         # Determine type and subtype for CNM
         granule_extension = pathlib.Path(granule_filename).suffix
@@ -247,7 +267,7 @@ def transform_files_to_cnm_product_files(cma_file_meta: Dict, file_type: str, su
     return cnm_file_meta
 
 
-def extract_granule_dates(granule_umm_json: dict) -> (str, str, str, str):
+def extract_granule_dates(granule_umm_json: dict, static_data_day: Optional[int] = None) -> tuple[str, str, str, str]:
     """
     Parse the begin, midpoint, end, and dataday for this granule
 
@@ -266,19 +286,28 @@ def extract_granule_dates(granule_umm_json: dict) -> (str, str, str, str):
     dataday
       day this granule applies to as string formatted "%Y%j
     """
-    time_range_dict = granule_umm_json['TemporalExtent']['RangeDateTime']
+    time_range_dict = granule_umm_json["TemporalExtent"]["RangeDateTime"]
 
     beginning_time_dt = parse_datetime(time_range_dict["BeginningDateTime"])
     ending_time_dt = parse_datetime(time_range_dict["EndingDateTime"])
     middle_time_dt = beginning_time_dt + (ending_time_dt - beginning_time_dt) / 2
 
-    begin = beginning_time_dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-    mid = middle_time_dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-    end = ending_time_dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    if static_data_day is None:
+        begin = beginning_time_dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        mid = middle_time_dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        end = ending_time_dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
-    middle_year = middle_time_dt.strftime("%Y")
-    day_of_year = middle_time_dt.strftime('%j')
-    dataday = middle_year + day_of_year
+        middle_year = middle_time_dt.strftime("%Y")
+        day_of_year = middle_time_dt.strftime("%j")
+        dataday = middle_year + day_of_year
+    else:
+        # If the static_data_day override is set, parse the year from the midpoint
+        # of the granule, and set all metadata dates to the doy that was set.
+        data_year = middle_time_dt.year
+        begin = parse_doy(data_year, static_data_day)
+        mid = begin
+        end = begin
+        dataday = middle_time_dt.strftime("%Y") + f"{static_data_day:03d}"
 
     return begin, mid, end, dataday
 
@@ -301,6 +330,27 @@ def parse_datetime(datetime_str: str) -> datetime:
         return datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%fZ")
     except ValueError:
         return datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_doy(year: int, doy: int) -> str:
+    """
+    Parses a year and day of year into a string.
+    
+    Parameters
+    ----------
+    year
+      integer year (parsed from midpoint of granule time range)
+    doy
+      static data day provided in DatasetConfiguration
+    
+    Returns
+    -------
+    str
+      a static Y-m-d format date string with the time set to midnight UTC 
+    """
+    jan_1 = datetime(year, 1, 1)
+    result_dt = jan_1 + timedelta(days=doy - 1)
+    return result_dt.strftime("%Y-%m-%dT00:00:00.000000Z")
 
 
 def create_metadata_xml(beginning_time: str, middle_time: str, ending_time: str, dataday: str,

--- a/bignbit/generate_image_metadata.py
+++ b/bignbit/generate_image_metadata.py
@@ -87,7 +87,7 @@ def generate_metadata(cma_file_list: List[Dict], granule_umm_json: Dict, temp_di
     temp_dir
       Temporary location to write xml file to prior to upload to s3
     static_data_day
-      Optionally, the DatasetConfiguration can override the date metadata in the 
+      Optionally, the DatasetConfiguration can override the date metadata in the
       granule umm-json
 
     Returns
@@ -335,18 +335,18 @@ def parse_datetime(datetime_str: str) -> datetime:
 def parse_doy(year: int, doy: int) -> str:
     """
     Parses a year and day of year into a string.
-    
+
     Parameters
     ----------
     year
       integer year (parsed from midpoint of granule time range)
     doy
       static data day provided in DatasetConfiguration
-    
+
     Returns
     -------
     str
-      a static Y-m-d format date string with the time set to midnight UTC 
+      a static Y-m-d format date string with the time set to midnight UTC
     """
     jan_1 = datetime(year, 1, 1)
     result_dt = jan_1 + timedelta(days=doy - 1)

--- a/tests/sample_messages/generate_image_metadata/cma.uat.input.OPERA_L3_DIST-ANN_mock.json
+++ b/tests/sample_messages/generate_image_metadata/cma.uat.input.OPERA_L3_DIST-ANN_mock.json
@@ -1,0 +1,1121 @@
+{
+  "cma": {
+    "task_config": {
+      "cumulus_message": {
+        "input": "{$.payload}"
+      }
+    },
+    "event": {
+      "meta": {
+        "buckets": {
+          "documentation": {
+            "name": "podaac-uat-cumulus-docs",
+            "type": "public"
+          },
+          "ecco-staging": {
+            "name": "podaac-ecco-v4r4",
+            "type": "internal"
+          },
+          "glacier": {
+            "name": "podaac-uat-cumulus-glacier",
+            "type": "orca"
+          },
+          "internal": {
+            "name": "svc-uat-big-internal",
+            "type": "internal"
+          },
+          "opera-dev-rs-fwd": {
+            "name": "opera-dev-rs-fwd*",
+            "type": "internal"
+          },
+          "opera-int-rs-fwd": {
+            "name": "opera-int-rs-fwd*",
+            "type": "internal"
+          },
+          "podaac-dev": {
+            "name": "podaac-dev-*",
+            "type": "internal"
+          },
+          "private": {
+            "name": "svc-uat-big-private",
+            "type": "private"
+          },
+          "protected": {
+            "name": "svc-uat-big-protected",
+            "type": "protected"
+          },
+          "public": {
+            "name": "svc-uat-big-public",
+            "type": "public"
+          },
+          "staging": {
+            "name": "svc-uat-big-staging",
+            "type": "internal"
+          }
+        },
+        "cmr": {
+          "clientId": "POCLOUD",
+          "cmrEnvironment": "UAT",
+          "cmrLimit": 100,
+          "cmrPageSize": 50,
+          "oauthProvider": "launchpad",
+          "provider": "POCLOUD",
+          "username": "podaaccumulus"
+        },
+        "collection": {
+          "createdAt": 1675991668650,
+          "updatedAt": 1676017294040,
+          "name": "OPERA_L3_DSWX-HLS_V1.0",
+          "version": "1.0",
+          "url_path": "{cmrMetadata.CollectionReference.ShortName}",
+          "duplicateHandling": "replace",
+          "granuleId": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*$",
+          "granuleIdExtraction": "^(OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*)((_.*_.*\\.tif)|(.*\\.md5)|(\\.context\\.json)|(\\.dataset\\.json)|(\\.cmr\\.json)|(\\.log)|(\\.catalog\\.json)|(\\.iso\\.xml)|(\\.png)|(BROWSE\\.tif)|(\\.met\\.json)|(\\.rc\\.yaml))?$",
+          "files": [
+            {
+              "type": "data",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*_.*_.*\\.tif$",
+              "bucket": "protected",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0__.tif"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.context\\.json$",
+              "bucket": "public",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.context.json"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.dataset\\.json$",
+              "bucket": "public",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.dataset.json"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.cmr\\.json$",
+              "bucket": "private",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.cmr.json"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.log$",
+              "bucket": "private",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.log"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.catalog\\.json$",
+              "bucket": "private",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.catalog.json"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.iso\\.xml$",
+              "bucket": "public",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.iso.xml"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.png$",
+              "bucket": "protected",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.png"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*BROWSE\\.tif$",
+              "bucket": "private",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0BROWSE.tif"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.met\\.json$",
+              "bucket": "public",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.met.json"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.rc\\.yaml$",
+              "bucket": "public",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.rc.yaml"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*_.*_.*\\.tif\\.md5$",
+              "bucket": "public",
+              "checksumFor": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*_.*_.*\\.tif$",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0__.tif.md5"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.context\\.json\\.md5$",
+              "bucket": "public",
+              "checksumFor": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.context\\.json$",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.context.json.md5"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.dataset\\.json\\.md5$",
+              "bucket": "public",
+              "checksumFor": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.dataset\\.json$",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.dataset.json.md5"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.log\\.md5$",
+              "bucket": "public",
+              "checksumFor": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.log$",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.log.md5"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.catalog\\.json\\.md5$",
+              "bucket": "public",
+              "checksumFor": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.catalog\\.json$",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.catalog.json.md5"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.iso\\.xml\\.md5$",
+              "bucket": "public",
+              "checksumFor": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.iso\\.xml$",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.iso.xml.md5"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.png\\.md5$",
+              "bucket": "public",
+              "checksumFor": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.png$",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.png.md5"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*BROWSE\\.tif\\.md5$",
+              "bucket": "public",
+              "checksumFor": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*BROWSE\\.tif$",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0BROWSE.tif.md5"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.met\\.json\\.md5$",
+              "bucket": "public",
+              "checksumFor": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.met\\.json$",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.met.json.md5"
+            },
+            {
+              "type": "metadata",
+              "regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.rc\\.yaml\\.md5$",
+              "bucket": "public",
+              "checksumFor": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.rc\\.yaml$",
+              "reportToEms": true,
+              "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0.rc.yaml.md5"
+            }
+          ],
+          "reportToEms": true,
+          "sampleFileName": "OPERA_L3_DSWx-HLS_LANDSAT-8_T22VEQ_20210905T143156_v1.0__.tif",
+          "meta": {
+            "iso-regex": "^OPERA_L3_DSWx-HLS_.*v([0-9]*)\\.([0-9]*).*\\.iso\\.xml$",
+            "glacier-bucket": "podaac-uat-cumulus-glacier",
+            "workflowChoice": {
+              "dmrpp": false,
+              "glacier": false,
+              "compressed": false,
+              "convertNetCDF": false,
+              "readDataFileForMetadata": false
+            },
+            "response-endpoint": [
+              "arn:aws:sns:us-west-2:123456789012:podaac-uat-cumulus-provider-response-sns"
+            ],
+            "granuleRecoveryWorkflow": "OrcaRecoveryWorkflow",
+            "granuleMetadataFileExtension": "cmr.json"
+          }
+        }
+      },
+      "payload": {
+        "granules": [
+          {
+            "createdAt": 1676017360358,
+            "granuleId": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0",
+            "dataType": "OPERA_L3_DSWX-HLS_V1.0",
+            "sync_granule_duration": 2055,
+            "files": [
+              {
+                "bucket": "podaac-uat-cumulus-protected",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif",
+                "size": 247009,
+                "checksumType": "md5",
+                "checksum": "5aa0d6f60acf9da18186559a213c0f19",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-protected",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif",
+                "size": 244564,
+                "checksumType": "md5",
+                "checksum": "d62d848a3d8c49cf9a21312dd2c4d7a8",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-protected",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif",
+                "size": 252298,
+                "checksumType": "md5",
+                "checksum": "aa983841dbb389b23fd9dcfa8c79c91f",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-protected",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif",
+                "size": 2039842,
+                "checksumType": "md5",
+                "checksum": "1fea9670f35c1594dd9d18d6ed23759b",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-protected",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif",
+                "size": 1168161,
+                "checksumType": "md5",
+                "checksum": "b0073c10af6d071acbcff61a476f61a6",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-protected",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif",
+                "size": 983771,
+                "checksumType": "md5",
+                "checksum": "a52fae6d34b3f9365aaf46c1c18be9f0",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-protected",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif",
+                "size": 752053,
+                "checksumType": "md5",
+                "checksum": "681264aaa2bf0a3f470112ff37d443fe",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-protected",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif",
+                "size": 1373226,
+                "checksumType": "md5",
+                "checksum": "a45cc1d434ec9f725c6f21e8721d4571",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-protected",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif",
+                "size": 456847,
+                "checksumType": "md5",
+                "checksum": "af7b79c93242b8c956db6d119bdf3fb3",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-protected",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif",
+                "size": 34081413,
+                "checksumType": "md5",
+                "checksum": "bc3c0f47f8308ad8834a6806e9b5a11a",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-private",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.tif",
+                "size": 246919,
+                "checksumType": "md5",
+                "checksum": "b95b205757912fcc407d2e3980612253",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.tif",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.tif"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-protected",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.png",
+                "size": 30588,
+                "checksumType": "md5",
+                "checksum": "4916e982f8218eee930deae06c12254d",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.png",
+                "type": "data",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.png"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-private",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.log",
+                "size": 38455,
+                "checksumType": "md5",
+                "checksum": "69a02f5541cefa27ec5c71920ee69141",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.log",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.log"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-private",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.catalog.json",
+                "size": 2585,
+                "checksumType": "md5",
+                "checksum": "d96985e4c57239d6c52ae8c547a39284",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.catalog.json",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.catalog.json"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-public",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.iso.xml",
+                "size": 77014,
+                "checksumType": "md5",
+                "checksum": "13efa3feb94c796e507556c657081fb1",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.iso.xml",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.iso.xml"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-public",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif.md5",
+                "size": 32,
+                "checksumType": "md5",
+                "checksum": "580155322182c950bd0fbf5f96451875",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif.md5",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif.md5"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-public",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif.md5",
+                "size": 32,
+                "checksumType": "md5",
+                "checksum": "efe2effc7c83cb41d01cca3e6a38aaac",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif.md5",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif.md5"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-public",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif.md5",
+                "size": 32,
+                "checksumType": "md5",
+                "checksum": "3aef5661f433c0828222ace91cde32e3",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif.md5",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif.md5"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-public",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif.md5",
+                "size": 32,
+                "checksumType": "md5",
+                "checksum": "f505b81138d9de8e8f4a5fd002ac2a09",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif.md5",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif.md5"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-public",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif.md5",
+                "size": 32,
+                "checksumType": "md5",
+                "checksum": "565ffeb14537d2f611f6c4e8748521aa",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif.md5",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif.md5"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-public",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif.md5",
+                "size": 32,
+                "checksumType": "md5",
+                "checksum": "7d4c542670d561dac2d03fb03b3e50bf",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif.md5",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif.md5"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-public",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif.md5",
+                "size": 32,
+                "checksumType": "md5",
+                "checksum": "0b21feae45ea4e521bd91e06d765f739",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif.md5",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif.md5"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-public",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif.md5",
+                "size": 32,
+                "checksumType": "md5",
+                "checksum": "f17da7edc6e9efbf3193db682155561f",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif.md5",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif.md5"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-public",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif.md5",
+                "size": 32,
+                "checksumType": "md5",
+                "checksum": "77a3b79a9e9fdd1434b4ec6bd92f6dec",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif.md5",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif.md5"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-public",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif.md5",
+                "size": 32,
+                "checksumType": "md5",
+                "checksum": "83c0ca178777b4f6cc15dda3d42a7e9b",
+                "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif.md5",
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif.md5"
+              },
+              {
+                "bucket": "podaac-uat-cumulus-private",
+                "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.cmr.json",
+                "size": 7965,
+                "type": "metadata",
+                "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.cmr.json"
+              }
+            ],
+            "version": "1.0",
+            "cmrLink": "https://cmr.uat.earthdata.nasa.gov/search/concepts/G1256529439-POCLOUD.umm_json",
+            "cmrConceptId": "G1256529439-POCLOUD",
+            "published": true,
+            "cmrMetadataFormat": "umm_json_v1_6_3",
+            "post_to_cmr_duration": 427
+          }
+        ],
+        "datasetConfigurationForBIG": {
+          "config": {
+            "sendToHarmony": "false",
+            "imageFilenameRegex": ".*BROWSE.tif",
+            "imgVariables": [
+              {
+                "id": "all"
+              }
+            ],
+            "dataDayStrategy": "single_day_of_year",
+            "singleDayNumber": "001",
+            "variables": []
+          }
+        },
+        "granule_umm_json": {
+          "PGEVersionClass": {
+            "PGEName": "DSWX_HLS_PGE",
+            "PGEVersion": "1.0.0-rc.6"
+          },
+          "RelatedUrls": [
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif",
+              "Type": "GET DATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "GET DATA VIA DIRECT ACCESS"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif",
+              "Type": "GET DATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "GET DATA VIA DIRECT ACCESS"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif",
+              "Type": "GET DATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "GET DATA VIA DIRECT ACCESS"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif",
+              "Type": "GET DATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "GET DATA VIA DIRECT ACCESS"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif",
+              "Type": "GET DATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "GET DATA VIA DIRECT ACCESS"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif",
+              "Type": "GET DATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "GET DATA VIA DIRECT ACCESS"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif",
+              "Type": "GET DATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "GET DATA VIA DIRECT ACCESS"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif",
+              "Type": "GET DATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "GET DATA VIA DIRECT ACCESS"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif",
+              "Type": "GET DATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "GET DATA VIA DIRECT ACCESS"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif",
+              "Type": "GET DATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "GET DATA VIA DIRECT ACCESS"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.png",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.png",
+              "Type": "GET DATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-protected/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.png",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "GET DATA VIA DIRECT ACCESS"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.iso.xml",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.iso.xml",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.iso.xml",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif.md5",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif.md5",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif.md5",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif.md5",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif.md5",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif.md5",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif.md5",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif.md5",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif.md5",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif.md5",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif.md5",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif.md5",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif.md5",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif.md5",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif.md5",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif.md5",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif.md5",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif.md5",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif.md5",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif.md5",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif.md5",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif.md5",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif.md5",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif.md5",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif.md5",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif.md5",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif.md5",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif.md5",
+              "Description": "Download OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif.md5",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "s3://podaac-uat-cumulus-public/OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif.md5",
+              "Description": "This link provides direct download access via S3 to the granule",
+              "Type": "EXTENDED METADATA"
+            },
+            {
+              "URL": "https://archive.podaac.uat.earthdata.nasa.gov/s3credentials",
+              "Description": "api endpoint to retrieve temporary credentials valid for same-region direct s3 access",
+              "Type": "VIEW RELATED INFORMATION"
+            }
+          ],
+          "SpatialExtent": {
+            "HorizontalSpatialDomain": {
+              "Geometry": {
+                "BoundingRectangles": [
+                  {
+                    "WestBoundingCoordinate": 102.775,
+                    "SouthBoundingCoordinate": 35.223,
+                    "EastBoundingCoordinate": 104.009,
+                    "NorthBoundingCoordinate": 36.229
+                  }
+                ]
+              }
+            }
+          },
+          "ProviderDates": [
+            {
+              "Type": "Insert",
+              "Date": "2023-02-10T08:23:07.104Z"
+            },
+            {
+              "Type": "Update",
+              "Date": "2023-02-10T08:23:07.105Z"
+            }
+          ],
+          "CollectionReference": {
+            "Version": "1.0",
+            "ShortName": "OPERA_L3_DSWX-HLS_V1.0"
+          },
+          "DataGranule": {
+            "ArchiveAndDistributionInformation": [
+              {
+                "SizeUnit": "MB",
+                "Size": 0.029170989990234375,
+                "Checksum": {
+                  "Value": "4916e982f8218eee930deae06c12254d",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 30588,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.png"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.23548030853271484,
+                "Checksum": {
+                  "Value": "b95b205757912fcc407d2e3980612253",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 246919,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.tif"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.0024652481079101562,
+                "Checksum": {
+                  "Value": "d96985e4c57239d6c52ae8c547a39284",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 2585,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.catalog.json"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.000030517578125,
+                "Checksum": {
+                  "Value": "580155322182c950bd0fbf5f96451875",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 32,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif.md5"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.07344627380371094,
+                "Checksum": {
+                  "Value": "13efa3feb94c796e507556c657081fb1",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 77014,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.iso.xml"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.036673545837402344,
+                "Checksum": {
+                  "Value": "69a02f5541cefa27ec5c71920ee69141",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 38455,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0.log"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.4356832504272461,
+                "Checksum": {
+                  "Value": "af7b79c93242b8c956db6d119bdf3fb3",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 456847,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 1.9453449249267578,
+                "Checksum": {
+                  "Value": "1fea9670f35c1594dd9d18d6ed23759b",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 2039842,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.000030517578125,
+                "Checksum": {
+                  "Value": "0b21feae45ea4e521bd91e06d765f739",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 32,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif.md5"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.23323440551757812,
+                "Checksum": {
+                  "Value": "d62d848a3d8c49cf9a21312dd2c4d7a8",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 244564,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.2355661392211914,
+                "Checksum": {
+                  "Value": "5aa0d6f60acf9da18186559a213c0f19",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 247009,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B01_WTR.tif"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.000030517578125,
+                "Checksum": {
+                  "Value": "f505b81138d9de8e8f4a5fd002ac2a09",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 32,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B04_DIAG.tif.md5"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.7172136306762695,
+                "Checksum": {
+                  "Value": "681264aaa2bf0a3f470112ff37d443fe",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 752053,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B07_LAND.tif"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 1.1140451431274414,
+                "Checksum": {
+                  "Value": "b0073c10af6d071acbcff61a476f61a6",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 1168161,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 32.50256824493408,
+                "Checksum": {
+                  "Value": "bc3c0f47f8308ad8834a6806e9b5a11a",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 34081413,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.000030517578125,
+                "Checksum": {
+                  "Value": "565ffeb14537d2f611f6c4e8748521aa",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 32,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B05_WTR-1.tif.md5"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.938197135925293,
+                "Checksum": {
+                  "Value": "a52fae6d34b3f9365aaf46c1c18be9f0",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 983771,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 1.309610366821289,
+                "Checksum": {
+                  "Value": "a45cc1d434ec9f725c6f21e8721d4571",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 1373226,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.000030517578125,
+                "Checksum": {
+                  "Value": "7d4c542670d561dac2d03fb03b3e50bf",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 32,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B06_WTR-2.tif.md5"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.000030517578125,
+                "Checksum": {
+                  "Value": "efe2effc7c83cb41d01cca3e6a38aaac",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 32,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B02_BWTR.tif.md5"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.000030517578125,
+                "Checksum": {
+                  "Value": "77a3b79a9e9fdd1434b4ec6bd92f6dec",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 32,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B09_CLOUD.tif.md5"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.24061012268066406,
+                "Checksum": {
+                  "Value": "aa983841dbb389b23fd9dcfa8c79c91f",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 252298,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.000030517578125,
+                "Checksum": {
+                  "Value": "3aef5661f433c0828222ace91cde32e3",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 32,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B03_CONF.tif.md5"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.000030517578125,
+                "Checksum": {
+                  "Value": "f17da7edc6e9efbf3193db682155561f",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 32,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B08_SHAD.tif.md5"
+              },
+              {
+                "SizeUnit": "MB",
+                "Size": 0.000030517578125,
+                "Checksum": {
+                  "Value": "83c0ca178777b4f6cc15dda3d42a7e9b",
+                  "Algorithm": "MD5"
+                },
+                "SizeInBytes": 32,
+                "Name": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_B10_DEM.tif.md5"
+              }
+            ],
+            "DayNightFlag": "Unspecified",
+            "Identifiers": [
+              {
+                "Identifier": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v1.0",
+                "IdentifierType": "ProducerGranuleId"
+              },
+              {
+                "Identifier": "0.5.1",
+                "IdentifierType": "Other",
+                "IdentifierName": "SASVersionId"
+              },
+              {
+                "Identifier": "1.0.0-rc.6",
+                "IdentifierType": "Other",
+                "IdentifierName": "PGEVersionId"
+              }
+            ],
+            "ProductionDateTime": "2023-01-31T22:23:41.149Z"
+          },
+          "TemporalExtent": {
+            "RangeDateTime": {
+              "EndingDateTime": "2023-03-02T03:43:50.037Z",
+              "BeginningDateTime": "2023-03-02T03:43:50.037Z"
+            }
+          },
+          "GranuleUR": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0",
+          "MetadataSpecification": {
+            "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.6.4",
+            "Name": "UMM-G",
+            "Version": "1.6.4"
+          },
+          "InputGranules": [
+            "/home/conda/input_dir/HLS.L30.T48SUE.2019061T034350.v2.0.B02.tif",
+            "/home/conda/input_dir/HLS.L30.T48SUE.2019061T034350.v2.0.B03.tif",
+            "/home/conda/input_dir/HLS.L30.T48SUE.2019061T034350.v2.0.B04.tif",
+            "/home/conda/input_dir/HLS.L30.T48SUE.2019061T034350.v2.0.B05.tif",
+            "/home/conda/input_dir/HLS.L30.T48SUE.2019061T034350.v2.0.B06.tif",
+            "/home/conda/input_dir/HLS.L30.T48SUE.2019061T034350.v2.0.B07.tif",
+            "/home/conda/input_dir/HLS.L30.T48SUE.2019061T034350.v2.0.Fmask.tif",
+            "/home/conda/input_dir/dem.vrt",
+            "/home/conda/input_dir/dem_0.tif",
+            "/home/conda/input_dir/landcover.tif",
+            "/home/conda/input_dir/worldcover.vrt",
+            "/home/conda/input_dir/worldcover_0.tif"
+          ]
+        },
+        "big": [
+          {
+            "bucket": "podaac-uat-cumulus-private",
+            "fileName": "OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.tif",
+            "size": 246919,
+            "checksumType": "md5",
+            "checksum": "b95b205757912fcc407d2e3980612253",
+            "source": "OPERA_L3_DSWX-HLS_PROVISIONAL_V0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.tif",
+            "type": "data",
+            "key": "OPERA_L3_DSWX-HLS_V1.0/OPERA_L3_DSWx-HLS_T48SUE_20190302T034350Z_20230131T222341Z_L8_30_v0.0_BROWSE.tif"
+          }
+        ]
+      },
+      "task_config": {
+        "cumulus_message": {
+          "input": "{$.payload}"
+        }
+      },
+      "exception": "None"
+    }
+  }
+}

--- a/tests/test_generate_image_metadata.py
+++ b/tests/test_generate_image_metadata.py
@@ -1,10 +1,12 @@
 import json
 import os
+import xml.etree.ElementTree as ET
 
 import bignbit.generate_image_metadata
 from moto import mock_s3
 
 import boto3
+import botocore
 
 
 @mock_s3
@@ -32,3 +34,50 @@ def test_process_opera_input():
     assert len(result['payload']['big']) == 2
     assert any([r['subtype'] == 'ImageMetadata-v1.2' for r in result['payload']['big']])
     assert any([r['subtype'] == 'geotiff' for r in result['payload']['big']])
+
+@mock_s3
+def test_process_static_data_day():
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    cma_json = json.load(open(os.path.join(
+        test_dir, 'sample_messages', 'generate_image_metadata',
+        'cma.uat.input.OPERA_L3_DIST-ANN_mock.json')))
+
+    buckets_to_create = set([b['name'] for _, b in cma_json['cma']['event']['meta']['buckets'].items()])
+    buckets_to_create = buckets_to_create.union(
+        set([granule_file['bucket'] for granule in cma_json['cma']['event']['payload']['granules'] for granule_file in
+             granule['files']]))
+
+    for bucket_name in buckets_to_create:
+        if "*" in bucket_name:
+            continue
+        aws_s3 = boto3.resource('s3', region_name='us-east-1')
+        aws_s3.create_bucket(Bucket=bucket_name)
+
+    result = bignbit.generate_image_metadata.lambda_handler(cma_json, {})
+    s3_mock = boto3.client('s3')
+    metadata_bucket = 'podaac-uat-cumulus-private'
+
+    assert result
+    # Assert two outputs, one image metadata xml and the other geotiff
+    assert len(result['payload']['big']) == 2
+    # Why is this any?
+    assert any([r['subtype'] == 'ImageMetadata-v1.2' for r in result['payload']['big']])
+    assert any([r['subtype'] == 'geotiff' for r in result['payload']['big']])
+    for r in result['payload']['big']:
+        metadata_xml = r['key']
+        try:
+            s3_mock.download_file(metadata_bucket, metadata_xml, r['fileName'])
+        except botocore.exceptions.ClientError:
+            print(f"could not stat s3://{metadata_bucket}/{metadata_xml}")
+            continue
+        md_tree = ET.parse(r['fileName'])
+        md_root = md_tree.getroot()
+        try:
+            for child in md_root:
+                if child.tag in ["DataStartDateTime", "DataMidDateTime", "DataEndDateTime"]:
+                    assert child.text == "2023-01-01T00:00:00.000000Z"
+                elif child.tag == "DataDay":
+                    assert child.text == "2023001"
+        finally:
+            os.remove(r['fileName'])
+        

--- a/tests/test_generate_image_metadata.py
+++ b/tests/test_generate_image_metadata.py
@@ -60,7 +60,6 @@ def test_process_static_data_day():
     assert result
     # Assert two outputs, one image metadata xml and the other geotiff
     assert len(result['payload']['big']) == 2
-    # Why is this any?
     assert any([r['subtype'] == 'ImageMetadata-v1.2' for r in result['payload']['big']])
     assert any([r['subtype'] == 'geotiff' for r in result['payload']['big']])
     for r in result['payload']['big']:


### PR DESCRIPTION
Also added instructions to readme

Github Issue: #59 

### Description
To support the OPERA DIST-ANN product, the granule data day should be static for all granules of a given year. This setting should apply globally at the DatasetConfiguration level, but not impact the configuration of other datasets.

### Overview of work done
I added support for two optional keywords in the datasetConfigurationForBIG component of a cma message (is there a schema for this that should be updated?). These keywords follow the convention layed out in the ticket:

{
        "dataDayStrategy":"single_day_of_year",
        "singleDayNumber": "001"
}
Additionally, as the setup of this repository required me to install miniconda fresh, I added a couple extra instructions to the readme to reflect some trouble that I had. This is not in the scope of the ticket, but hopefully that's not a problem.

### Overview of verification done
The other unit test in the bignbit test directory for this capability should ensure that there are no regressions when these keywords are not specified, and I have added a single new unit test to ensure the metadata xml is as expected. This is not an exhaustive test, if we wanted to test more thoroughly we would want to:

Attempt to specify other days of year, especially during a leap year
Ensure bignbit throws an error as expected if the config contains invalid data
Validate the behavior when dataDayStrategy is specified but is not "single_day_of_year"

### Overview of integration done
Integration testing has not yet been performed on this PR.

## PR checklist:

* [x] Linted
* [x] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_