### PR TITLE
PCESA-3224: Support for subdaily granules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [0.3.0]
+### Added
+- [issues/84](https://github.com/podaac/bignbit/issues/84): New parameter in dataset config `subdaily` that sends DataDateTime to GIBS instead of DataDay.
+- [issues/82](https://github.com/podaac/bignbit/issues/82): Fixed date parsing bug where ISO-8601 format dates, the default for UMM-G, were not handled properly.
+- Added optional `concept_id` keyword to dataset config to provide an override for finding the proper CMR collection concept ID when testing.
+
 ## [0.2.4]
 ### Added
 - [issues/71](https://github.com/podaac/bignbit/issues/71): New module parameter `cmr_environment` is used to determine which environment to use for CMR requests when processing GIBS responses.

--- a/bignbit/generate_image_metadata.py
+++ b/bignbit/generate_image_metadata.py
@@ -53,8 +53,7 @@ class CMA(Process):
             cma_file_list = [item for sublist in cma_file_list for item in sublist]
         granule_umm_json = self.input['granule_umm_json']
 
-        # TO DO: perhaps there is a more organized way of managing these
-        # dataset-level overrides?
+        # Parse dataset-level overrides
         dataset_config = self.input['datasetConfigurationForBIG']['config']
         data_day_strat = dataset_config.get('dataDayStrategy')
         if data_day_strat is not None and data_day_strat == 'single_day_of_year':

--- a/bignbit/generate_image_metadata.py
+++ b/bignbit/generate_image_metadata.py
@@ -7,7 +7,7 @@ import pathlib
 import uuid
 import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from cumulus_logger import CumulusLogger
 from cumulus_process import Process
@@ -63,15 +63,27 @@ class CMA(Process):
             static_data_day = int(static_data_day)
         else:
             static_data_day = None
+        
+        subdaily = dataset_config.get('subdaily', False)
 
-        file_metadata_list = generate_metadata(cma_file_list, granule_umm_json, pathlib.Path(f"{self.path}"), static_data_day)
+        file_metadata_list = generate_metadata(
+            cma_file_list, granule_umm_json,
+            pathlib.Path(f"{self.path}"),
+            static_data_day,
+            subdaily
+        )
         del self.input['granule_umm_json']
         del self.input['big']
         self.input['big'] = file_metadata_list
         return self.input
 
 
-def generate_metadata(cma_file_list: List[Dict], granule_umm_json: Dict, temp_dir: pathlib.Path, static_data_day: Optional[int] = None) -> List[Dict]:
+def generate_metadata(
+        cma_file_list: List[Dict],
+        granule_umm_json: Dict,
+        temp_dir: pathlib.Path,
+        static_data_day: int | None = None,
+        subdaily: bool = False) -> List[Dict]:
     """
     For each file in the list, create an ImageMetadata-v1.2 xml file and upload it to s3 in the same
     bucket and path as the image file.
@@ -89,6 +101,8 @@ def generate_metadata(cma_file_list: List[Dict], granule_umm_json: Dict, temp_di
     static_data_day
       Optionally, the DatasetConfiguration can override the date metadata in the
       granule umm-json
+    subdaily
+      boolean flag if product is subdaily (if True, add DataDateTime to metadata)
 
     Returns
     -------
@@ -133,7 +147,7 @@ def generate_metadata(cma_file_list: List[Dict], granule_umm_json: Dict, temp_di
 
         # If this is a browse image, generate image metadata for it and upload it to s3
         if granule_type == 'browse':
-            image_metadata_xml = create_metadata_xml(begin, mid, end, dataday, partial_id)
+            image_metadata_xml = create_metadata_xml(begin, mid, end, dataday, subdaily, partial_id)
             temp_xml_path = write_image_metadata_xml(image_metadata_xml, temp_dir)
             image_metadata_xml_metadata = get_file_metadata_for_image_metadta_xml(temp_xml_path, cnm_file_meta)
             s3_uri = upload_image_metadata_xml(image_metadata_xml_metadata, temp_xml_path)
@@ -267,7 +281,7 @@ def transform_files_to_cnm_product_files(cma_file_meta: Dict, file_type: str, su
     return cnm_file_meta
 
 
-def extract_granule_dates(granule_umm_json: dict, static_data_day: Optional[int] = None) -> tuple[str, str, str, str]:
+def extract_granule_dates(granule_umm_json: dict, static_data_day: int | None = None) -> tuple[str, str, str, str]:
     """
     Parse the begin, midpoint, end, and dataday for this granule
 
@@ -326,10 +340,21 @@ def parse_datetime(datetime_str: str) -> datetime:
     datetime
       a datetime object
     """
-    try:
-        return datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%fZ")
-    except ValueError:
-        return datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%SZ")
+    formats = [
+        "%Y-%m-%dT%H:%M:%S.%fZ",        # 2023-01-01T12:30:45.123456Z
+        "%Y-%m-%dT%H:%M:%SZ",           # 2023-01-01T12:30:45Z
+        "%Y-%m-%dT%H:%M:%S.%f%z",       # 2023-01-01T12:30:45.123456+00:00
+        "%Y-%m-%dT%H:%M:%S%z",          # 2023-01-01T12:30:45+00:00
+    ]
+    
+    for fmt in formats:
+        try:
+            return datetime.strptime(datetime_str, fmt)
+        except ValueError:
+            continue
+    
+    # If none of the formats worked
+    raise ValueError(f"Unable to parse datetime string: {datetime_str}")
 
 
 def parse_doy(year: int, doy: int) -> str:
@@ -354,7 +379,7 @@ def parse_doy(year: int, doy: int) -> str:
 
 
 def create_metadata_xml(beginning_time: str, middle_time: str, ending_time: str, dataday: str,
-                        partial_id: str = None) -> ET.ElementTree:
+                        subdaily: bool = False, partial_id: str | None = None) -> ET.ElementTree:
     """
     Create an ImageMetadata-v1.2 XML Element tree
 
@@ -368,6 +393,8 @@ def create_metadata_xml(beginning_time: str, middle_time: str, ending_time: str,
       formatted datetime string for data end date time
     dataday
       string if format %Y%j for day of year the data represents
+    subdaily
+      boolean flag if product is subdaily (if True, add DataDateTime to metadata)
     partial_id
       partial id associated with data
 
@@ -384,7 +411,10 @@ def create_metadata_xml(beginning_time: str, middle_time: str, ending_time: str,
     ET.SubElement(imagery_metadata, "DataStartDateTime").text = beginning_time
     ET.SubElement(imagery_metadata, "DataMidDateTime").text = middle_time
     ET.SubElement(imagery_metadata, "DataEndDateTime").text = ending_time
-    ET.SubElement(imagery_metadata, "DataDay").text = dataday
+    if subdaily:
+        ET.SubElement(imagery_metadata, "DataDateTime").text = beginning_time
+    else:
+        ET.SubElement(imagery_metadata, "DataDay").text = dataday
     if partial_id:
         ET.SubElement(imagery_metadata, "PartialId").text = partial_id
 

--- a/bignbit/get_collection_concept_id.py
+++ b/bignbit/get_collection_concept_id.py
@@ -33,7 +33,11 @@ class CMA(Process):
         collection_shortname = self.config['collection_shortname']
         cmr_provider = self.config['cmr_provider']
         cmr_environment = self.config['cmr_environment']
-        collection_id = get_collection_concept_id(collection_shortname, cmr_provider, cmr_environment)
+        dataset_config = self.input['datasetConfigurationForBIG']['config']
+        # Use override for collection concept id from dataset config if provided
+        collection_id = dataset_config.get('concept_id')
+        if collection_id is None:
+          collection_id = get_collection_concept_id(collection_shortname, cmr_provider, cmr_environment)
         self.input['collection_concept_id'] = collection_id
         return self.input
 

--- a/tests/sample_messages/generate_image_metadata/cma.uat.input.TEMPO_NO2_L3.json
+++ b/tests/sample_messages/generate_image_metadata/cma.uat.input.TEMPO_NO2_L3.json
@@ -1,0 +1,423 @@
+{
+    "cma": {
+        "cumulus_meta":{
+            
+        },
+        "event": {
+            "meta":{
+                "buckets":{
+                    "internal": {
+                        "name": "podaac-sit-svc-internal",
+                        "type": "internal"
+                    },
+                    "private": {
+                        "name": "podaac-sit-svc-private",
+                        "type": "private"
+                    }
+                },
+                "cmr":{
+                    "clientId":"POCLOUD",
+                    "cmrEnvironment":"UAT",
+                    "provider":"LARC_CLOUD"
+                },
+                "collection":{
+                    "name":"TEMPO_NO2_L3"
+                },
+                "stack":"podaac-uat-cumulus",
+                "provider":{
+                    
+                }
+            },
+            "payload":{
+                "granules":{
+                    "files": [
+                        {
+                            "bucket": "podaac-sit-svc-private",
+                            "fileName": "TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc",
+                            "granuleId":"TEMPO_NO2_L3_V03_20250422T114702Z_S003",
+                            "provider":"larc",
+                            "cmrLink":"https://cmr.uat.earthdata.nasa.gov/search/concepts/G1273455903-LARC_CLOUD.umm_json",
+                            "cmrConceptId":"G1273455903-LARC_CLOUD"
+                        }
+                    ]
+                },
+                "granule_umm_json": {
+                    "PGEVersionClass": {
+                        "PGEVersion": "1.0.0"
+                    },
+                    "RelatedUrls": [
+                        {
+                        "URL": "https://data.asdc.uat.earthdata.nasa.gov/asdc2-uat-protected/TEMPO/TEMPO_NO2_L3_V03/2025.04.22/TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc",
+                        "Description": "Download TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc",
+                        "Type": "GET DATA"
+                        },
+                        {
+                        "URL": "https://data.asdc.uat.earthdata.nasa.gov/asdc2-uat-protected/TEMPO/TEMPO_NO2_L3_V03/2025.04.22/TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc.met",
+                        "Description": "Download TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc.met",
+                        "Type": "EXTENDED METADATA"
+                        },
+                        {
+                        "URL": "https://data.asdc.uat.earthdata.nasa.gov/asdc2-uat-public/TEMPO/TEMPO_NO2_L3_V03/2025.04.22/thumb-TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc.png",
+                        "Description": "Download thumb-TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc.png",
+                        "Type": "GET RELATED VISUALIZATION"
+                        },
+                        {
+                        "URL": "s3://asdc2-uat-protected/TEMPO/TEMPO_NO2_L3_V03/2025.04.22/TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc",
+                        "Description": "This link provides direct download access via S3 to the granule",
+                        "Type": "GET DATA VIA DIRECT ACCESS"
+                        },
+                        {
+                        "URL": "s3://asdc2-uat-protected/TEMPO/TEMPO_NO2_L3_V03/2025.04.22/TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc.met",
+                        "Description": "This link provides direct download access via S3 to the granule",
+                        "Type": "EXTENDED METADATA"
+                        },
+                        {
+                        "URL": "s3://asdc2-uat-public/TEMPO/TEMPO_NO2_L3_V03/2025.04.22/thumb-TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc.png",
+                        "Description": "This link provides direct download access via S3 to the granule",
+                        "Type": "GET RELATED VISUALIZATION"
+                        },
+                        {
+                        "URL": "https://data.asdc.uat.earthdata.nasa.gov/s3credentials",
+                        "Description": "api endpoint to retrieve temporary credentials valid for same-region direct s3 access",
+                        "Type": "VIEW RELATED INFORMATION"
+                        },
+                        {
+                        "URL": "https://opendap.uat.earthdata.nasa.gov/collections/C1262899964-LARC_CLOUD/granules/TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc",
+                        "Type": "USE SERVICE API",
+                        "Subtype": "OPENDAP DATA",
+                        "Description": "OPeNDAP request URL"
+                        }
+                    ],
+                    "AccessConstraints": {
+                        "Description": "WORLD",
+                        "Value": 4
+                    },
+                    "SpatialExtent": {
+                        "HorizontalSpatialDomain": {
+                        "Geometry": {
+                            "GPolygons": [
+                            {
+                                "Boundary": {
+                                "Points": [
+                                    {
+                                    "Latitude": 57.66,
+                                    "Longitude": -110.94
+                                    },
+                                    {
+                                    "Latitude": 53.38,
+                                    "Longitude": -108.58
+                                    },
+                                    {
+                                    "Latitude": 49.52,
+                                    "Longitude": -106.94
+                                    },
+                                    {
+                                    "Latitude": 44.96,
+                                    "Longitude": -105.42
+                                    },
+                                    {
+                                    "Latitude": 40,
+                                    "Longitude": -104.14
+                                    },
+                                    {
+                                    "Latitude": 34.86,
+                                    "Longitude": -103.12
+                                    },
+                                    {
+                                    "Latitude": 28.98,
+                                    "Longitude": -102.24
+                                    },
+                                    {
+                                    "Latitude": 23.32,
+                                    "Longitude": -101.62
+                                    },
+                                    {
+                                    "Latitude": 17.26,
+                                    "Longitude": -101.16
+                                    },
+                                    {
+                                    "Latitude": 17.24,
+                                    "Longitude": -82.84
+                                    },
+                                    {
+                                    "Latitude": 17.5,
+                                    "Longitude": -65.12
+                                    },
+                                    {
+                                    "Latitude": 22.5,
+                                    "Longitude": -63.98
+                                    },
+                                    {
+                                    "Latitude": 25.78,
+                                    "Longitude": -63.04
+                                    },
+                                    {
+                                    "Latitude": 29.54,
+                                    "Longitude": -61.74001
+                                    },
+                                    {
+                                    "Latitude": 33.2,
+                                    "Longitude": -60.2
+                                    },
+                                    {
+                                    "Latitude": 36.22,
+                                    "Longitude": -58.68
+                                    },
+                                    {
+                                    "Latitude": 39.52,
+                                    "Longitude": -56.7
+                                    },
+                                    {
+                                    "Latitude": 42.44,
+                                    "Longitude": -54.60001
+                                    },
+                                    {
+                                    "Latitude": 45.34,
+                                    "Longitude": -52.10001
+                                    },
+                                    {
+                                    "Latitude": 48.08,
+                                    "Longitude": -49.24001
+                                    },
+                                    {
+                                    "Latitude": 50.74,
+                                    "Longitude": -45.84
+                                    },
+                                    {
+                                    "Latitude": 53.12,
+                                    "Longitude": -42.06001
+                                    },
+                                    {
+                                    "Latitude": 55.04,
+                                    "Longitude": -38.28
+                                    },
+                                    {
+                                    "Latitude": 56.62,
+                                    "Longitude": -34.44
+                                    },
+                                    {
+                                    "Latitude": 58.04,
+                                    "Longitude": -30.12001
+                                    },
+                                    {
+                                    "Latitude": 59.14,
+                                    "Longitude": -25.84
+                                    },
+                                    {
+                                    "Latitude": 60.06,
+                                    "Longitude": -21
+                                    },
+                                    {
+                                    "Latitude": 60.26,
+                                    "Longitude": -20.52
+                                    },
+                                    {
+                                    "Latitude": 60.36,
+                                    "Longitude": -19.82001
+                                    },
+                                    {
+                                    "Latitude": 61.16,
+                                    "Longitude": -19.8
+                                    },
+                                    {
+                                    "Latitude": 61.14,
+                                    "Longitude": -20.06
+                                    },
+                                    {
+                                    "Latitude": 61.42,
+                                    "Longitude": -20.08
+                                    },
+                                    {
+                                    "Latitude": 61.38,
+                                    "Longitude": -20.32001
+                                    },
+                                    {
+                                    "Latitude": 62.28,
+                                    "Longitude": -20.34
+                                    },
+                                    {
+                                    "Latitude": 62.26,
+                                    "Longitude": -20.52
+                                    },
+                                    {
+                                    "Latitude": 62.36,
+                                    "Longitude": -20.64
+                                    },
+                                    {
+                                    "Latitude": 63.14,
+                                    "Longitude": -20.66
+                                    },
+                                    {
+                                    "Latitude": 63,
+                                    "Longitude": -21.62001
+                                    },
+                                    {
+                                    "Latitude": 63.5,
+                                    "Longitude": -21.64
+                                    },
+                                    {
+                                    "Latitude": 63.48,
+                                    "Longitude": -21.84
+                                    },
+                                    {
+                                    "Latitude": 63.86,
+                                    "Longitude": -21.92
+                                    },
+                                    {
+                                    "Latitude": 62.24,
+                                    "Longitude": -33.56
+                                    },
+                                    {
+                                    "Latitude": 60.82,
+                                    "Longitude": -44.18
+                                    },
+                                    {
+                                    "Latitude": 59.24,
+                                    "Longitude": -58.94
+                                    },
+                                    {
+                                    "Latitude": 58.8,
+                                    "Longitude": -63.66
+                                    },
+                                    {
+                                    "Latitude": 58.2,
+                                    "Longitude": -72.34
+                                    },
+                                    {
+                                    "Latitude": 57.76,
+                                    "Longitude": -83.38
+                                    },
+                                    {
+                                    "Latitude": 57.66,
+                                    "Longitude": -91.4
+                                    },
+                                    {
+                                    "Latitude": 57.8,
+                                    "Longitude": -101.06
+                                    },
+                                    {
+                                    "Latitude": 58,
+                                    "Longitude": -106.34
+                                    },
+                                    {
+                                    "Latitude": 58.26,
+                                    "Longitude": -110.94
+                                    },
+                                    {
+                                    "Latitude": 57.66,
+                                    "Longitude": -110.94
+                                    }
+                                ]
+                                }
+                            }
+                            ]
+                        }
+                        }
+                    },
+                    "ProviderDates": [
+                        {
+                        "Date": "2025-04-22T17:20:32.548Z",
+                        "Type": "Create"
+                        },
+                        {
+                        "Date": "2025-04-22T17:20:32.548Z",
+                        "Type": "Update"
+                        }
+                    ],
+                    "CollectionReference": {
+                        "ShortName": "TEMPO_NO2_L3",
+                        "Version": "V03"
+                    },
+                    "DataGranule": {
+                        "ArchiveAndDistributionInformation": [
+                        {
+                            "Checksum": {
+                            "Algorithm": "MD5",
+                            "Value": "170c05d8975d9a9159c23fecf2940f3d"
+                            },
+                            "Name": "TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc",
+                            "Size": 540.965558052063,
+                            "SizeUnit": "MB"
+                        },
+                        {
+                            "Checksum": {
+                            "Algorithm": "MD5",
+                            "Value": "4d4ef5459d539fb9202ab08f1d742058"
+                            },
+                            "Name": "TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc.met",
+                            "Size": 5.1953125,
+                            "SizeUnit": "KB"
+                        }
+                        ],
+                        "DayNightFlag": "Unspecified",
+                        "Identifiers": [
+                        {
+                            "Identifier": "TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc",
+                            "IdentifierType": "ProducerGranuleId"
+                        },
+                        {
+                            "Identifier": "RFC1321 MD5 = not yet calculated",
+                            "IdentifierType": "LocalVersionId"
+                        }
+                        ],
+                        "ProductionDateTime": "2025-04-22T17:05:56+00:00"
+                    },
+                    "TemporalExtent": {
+                        "RangeDateTime": {
+                        "BeginningDateTime": "2025-04-22T11:47:02+00:00",
+                        "EndingDateTime": "2025-04-22T12:26:51+00:00"
+                        }
+                    },
+                    "GranuleUR": "TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc",
+                    "Projects": [
+                        {
+                        "ShortName": "TEMPO"
+                        }
+                    ],
+                    "MetadataSpecification": {
+                        "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.6.6",
+                        "Name": "UMM-G",
+                        "Version": "1.6.6"
+                    },
+                    "InputGranules": [
+                        "TEMPO_NO2_L2_V03_20250422T114702Z_S003G01.nc",
+                        "TEMPO_NO2_L2_V03_20250422T115342Z_S003G02.nc",
+                        "TEMPO_NO2_L2_V03_20250422T120022Z_S003G03.nc",
+                        "TEMPO_NO2_L2_V03_20250422T120700Z_S003G04.nc",
+                        "TEMPO_NO2_L2_V03_20250422T121337Z_S003G05.nc",
+                        "TEMPO_NO2_L2_V03_20250422T122014Z_S003G06.nc"
+                    ]
+                },
+                "big": [
+                    {
+                        "bucket": "podaac-sit-svc-private",
+                        "fileName": "TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc",
+                        "type": "data",
+                        "key": "TEMPO_NO2_L3/TEMPO_NO2_L3_V03_20250422T114702Z_S003.nc"
+                    }
+                ],
+                "datasetConfigurationForBIG": {
+                    "config": {
+                        "sendToHarmony":true,
+                        "latVar":"latitude",
+                        "lonVar":"longiude",
+                        "timeVar":"time",
+                        "subdaily":true,
+                        "imgVariables":[
+                            {"id": "product/vertical_column_stratosphere","title":"stratosphere nitrogen dioxide vertical column","units":"molecules/cm^2","min":"0.0","max":"5.0"}
+                        ],
+                        "height":2950,
+                        "width":7750,
+                        "variables":["time","latitude","longitude","product/vertical_column_stratosphere"]
+                    }
+                }
+            },
+            "task_config": {
+                "cumulus_message": {
+                    "input": "{$.payload}"
+                }
+            },
+            "exception": "None"
+        }
+    }
+}


### PR DESCRIPTION
Github Issue: 

### Description

- [issues/84](https://github.com/podaac/bignbit/issues/84): New parameter in dataset config `subdaily` that sends DataDateTime to GIBS instead of DataDay.
- [issues/82](https://github.com/podaac/bignbit/issues/82): Fixed date parsing bug where ISO-8601 format dates, the default for UMM-G, were not handled properly.
- Added optional `concept_id` keyword to dataset config to provide an override for finding the proper CMR collection concept ID when testing.

### Overview of work done

Added two keywords and fixed one bug. Added one unit test to handle new functionality.

### Overview of verification done

Added a unit test that provides coverage of both github issues referenced in this PR.

### Overview of integration done

My plan is to create a 0.3.0 release which can then be deployed to SIT for integration testing. TEMPO L3 subdaily data will be tested end-to-end on that venue before deploying to UAT.

## PR checklist:

* [ ] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_