### PR TITLE
Issues/89: Use shortname, provider, and version when looking up collection concept id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
-- [issues/91](https://github.com/podaac/bignbit/issues/91): Fixed bug where the CNM collection name sent to GIBS included '/' characters when dealing with certain variables. This caused processing errors in GIBS, all collection names will now replace '/' with '_' before being sent to GIBS. 
+- [issues/91](https://github.com/podaac/bignbit/issues/91): Fixed bug where the CNM collection name sent to GIBS included '/' characters when dealing with certain variables. This caused processing errors in GIBS, all collection names will now replace '/' with '_' before being sent to GIBS.
+- [issues/89](https://github.com/podaac/bignbit/issues/89): Fixed bug where querying CMR for a collection could result in multiple results because collection version was not included in the query. Fix is to include the version in the CMR query, which will now return only one result.
 ### Security
 
 ## [0.3.0]

--- a/bignbit/get_collection_concept_id.py
+++ b/bignbit/get_collection_concept_id.py
@@ -31,24 +31,27 @@ class CMA(Process):
           The input with new key 'collection_concept_id' added in the payload
         """
         collection_shortname = self.config['collection_shortname']
+        collection_version = self.config['collection_version']
         cmr_provider = self.config['cmr_provider']
         cmr_environment = self.config['cmr_environment']
         dataset_config = self.input['datasetConfigurationForBIG']['config']
         # Use override for collection concept id from dataset config if provided
         collection_id = dataset_config.get('concept_id')
         if collection_id is None:
-            collection_id = get_collection_concept_id(collection_shortname, cmr_provider, cmr_environment)
+            collection_id = get_collection_concept_id(collection_shortname, collection_version, cmr_provider, cmr_environment)
         self.input['collection_concept_id'] = collection_id
         return self.input
 
 
-def get_collection_concept_id(collection_shortname: str, cmr_provider: str, cmr_environment: str) -> str:
+def get_collection_concept_id(collection_shortname: str, collection_version: str, cmr_provider: str, cmr_environment: str) -> str:
     """
     Retrieve the collection concept id from CMR
     Parameters
     ----------
     collection_shortname
       Shortname of the collection
+    collection_version
+      Version of the collection
     cmr_provider
       Collection provider
     cmr_environment
@@ -67,7 +70,8 @@ def get_collection_concept_id(collection_shortname: str, cmr_provider: str, cmr_
                                      headers={'Authorization': f'Bearer {token}'},
                                      params={
                                          'provider': cmr_provider,
-                                         'short_name': collection_shortname
+                                         'short_name': collection_shortname,
+                                         'version': collection_version
                                      },
                                      timeout=10)
     umm_json_response.raise_for_status()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1604,7 +1604,7 @@ version = "6.6.4"
 description = "multidict implementation"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "multidict-6.6.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b8aa6f0bd8125ddd04a6593437bad6a7e70f300ff4180a531654aa2ab3f6d58f"},
     {file = "multidict-6.6.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b9e5853bbd7264baca42ffc53391b490d65fe62849bf2c690fa3f6273dbcd0cb"},
@@ -1924,7 +1924,7 @@ version = "0.3.2"
 description = "Accelerated property cache"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "propcache-0.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:22d9962a358aedbb7a2e36187ff273adeaab9743373a272976d2e348d08c7770"},
     {file = "propcache-0.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0d0fda578d1dc3f77b6b5a5dce3b9ad69a8250a891760a548df850a5e8da87f3"},
@@ -2175,6 +2175,26 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+
+[[package]]
+name = "pytest-recording"
+version = "0.13.4"
+description = "A pytest plugin powered by VCR.py to record and replay HTTP traffic"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_recording-0.13.4-py3-none-any.whl", hash = "sha256:ad49a434b51b1c4f78e85b1e6b74fdcc2a0a581ca16e52c798c6ace971f7f439"},
+    {file = "pytest_recording-0.13.4.tar.gz", hash = "sha256:568d64b2a85992eec4ae0a419c855d5fd96782c5fb016784d86f18053792768c"},
+]
+
+[package.dependencies]
+pytest = ">=3.5.0"
+vcrpy = ">=2.0.1"
+
+[package.extras]
+dev = ["pytest-httpbin", "pytest-mock", "requests", "werkzeug (==3.1.3)"]
+tests = ["pytest-httpbin", "pytest-mock", "requests", "werkzeug (==3.1.3)"]
 
 [[package]]
 name = "python-dateutil"
@@ -2577,6 +2597,30 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress ; py
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "vcrpy"
+version = "7.0.0"
+description = "Automatically mock your HTTP interactions to simplify and speed up testing"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "vcrpy-7.0.0-py2.py3-none-any.whl", hash = "sha256:55791e26c18daa363435054d8b35bd41a4ac441b6676167635d1b37a71dbe124"},
+    {file = "vcrpy-7.0.0.tar.gz", hash = "sha256:176391ad0425edde1680c5b20738ea3dc7fb942520a48d2993448050986b3a50"},
+]
+
+[package.dependencies]
+PyYAML = "*"
+urllib3 = [
+    {version = "<2", markers = "platform_python_implementation == \"PyPy\""},
+    {version = "*", markers = "platform_python_implementation != \"PyPy\" and python_version >= \"3.10\""},
+]
+wrapt = "*"
+yarl = "*"
+
+[package.extras]
+tests = ["Werkzeug (==2.0.3)", "aiohttp", "boto3", "httplib2", "httpx", "pytest", "pytest-aiohttp", "pytest-asyncio", "pytest-cov", "pytest-httpbin", "requests (>=2.22.0)", "tornado", "urllib3"]
+
+[[package]]
 name = "websockets"
 version = "15.0.1"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
@@ -2780,7 +2824,7 @@ version = "1.20.1"
 description = "Yet another URL library"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "yarl-1.20.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6032e6da6abd41e4acda34d75a816012717000fa6839f37124a47fcefc49bec4"},
     {file = "yarl-1.20.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2c7b34d804b8cf9b214f05015c4fee2ebe7ed05cf581e7192c06555c71f4446a"},
@@ -2896,4 +2940,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "e2fb4acbe9436a3ce5bf3737eafc92d070740360e2c5c1ca272dbb942a67ce02"
+content-hash = "567242ec33d22ad5ad8ea0ddd9f3305b16c729321f88944c915b7e60a4f1a0f3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ pylint = "^2.15.8"
 flake8 = "^6.0.0"
 pytest-cov = "^4.1.0"
 boto3-stubs = "^1.40.6"
+vcrpy = "^7.0.0"
+pytest-recording = "^0.13.4"
 
 [build-system]
 requires = ["poetry-core"]

--- a/terraform/state_machine_definition.tpl
+++ b/terraform/state_machine_definition.tpl
@@ -200,6 +200,7 @@
           "event.$":"$",
           "task_config":{
             "collection_shortname":"{$.meta.collection.name}",
+            "collection_version":"{$.meta.collection.version}",
             "cmr_provider":"{$.meta.cmr.provider}",
             "cmr_environment":"{$.meta.cmr.cmrEnvironment}",
             "cumulus_message":{

--- a/tests/cassettes/test_get_collection_concept_id/test_get_collection_concept_id[MUR-JPL-L4-GLOB-v4.1].yaml
+++ b/tests/cassettes/test_get_collection_concept_id/test_get_collection_concept_id[MUR-JPL-L4-GLOB-v4.1].yaml
@@ -1,0 +1,200 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.4
+    method: GET
+    uri: https://cmr.uat.earthdata.nasa.gov/search/collections.umm_json?provider=POCLOUD&short_name=MUR-JPL-L4-GLOB-v4.1&version=4.1
+  response:
+    body:
+      string: "{\"hits\":1,\"took\":9,\"items\":[{\"meta\":{\"revision-id\":1115,\"deleted\":false,\"format\":\"application/vnd.nasa.cmr.umm+json\",\"provider-id\":\"POCLOUD\",\"has-combine\":false,\"user-id\":\"viviant\",\"has-formats\":true,\"associations\":{\"variables\":[\"V1241047544-POCLOUD\",\"V1241047538-POCLOUD\",\"V1244919092-POCLOUD\",\"V1241047534-POCLOUD\",\"V1241047540-POCLOUD\",\"V1241047546-POCLOUD\",\"V1241047536-POCLOUD\",\"V1241047542-POCLOUD\"],\"services\":[\"S1245706235-POCLOUD\",\"S1245787332-EEDTEST\"],\"tools\":[\"TL1244140294-POCLOUD\"]},\"s3-links\":[\"podaac-ops-cumulus-public/MUR-JPL-L4-GLOB-v4.1/\",\"podaac-ops-cumulus-protected/MUR-JPL-L4-GLOB-v4.1/\"],\"has-spatial-subsetting\":true,\"native-id\":\"GHRSST+Level+4+MUR+Global+Foundation+Sea+Surface+Temperature+Analysis+(v4.1)\",\"has-transforms\":false,\"association-details\":{\"variables\":[{\"concept-id\":\"V1241047544-POCLOUD\"},{\"concept-id\":\"V1241047538-POCLOUD\"},{\"concept-id\":\"V1244919092-POCLOUD\"},{\"concept-id\":\"V1241047534-POCLOUD\"},{\"concept-id\":\"V1241047540-POCLOUD\"},{\"concept-id\":\"V1241047546-POCLOUD\"},{\"concept-id\":\"V1241047536-POCLOUD\"},{\"concept-id\":\"V1241047542-POCLOUD\"}],\"services\":[{\"concept-id\":\"S1245706235-POCLOUD\"},{\"concept-id\":\"S1245787332-EEDTEST\"}],\"tools\":[{\"concept-id\":\"TL1244140294-POCLOUD\"}]},\"has-variables\":true,\"concept-id\":\"C1238621141-POCLOUD\",\"revision-date\":\"2025-08-11T11:06:39.505Z\",\"has-temporal-subsetting\":true,\"concept-type\":\"collection\"},\"umm\":{\"DataLanguage\":\"eng\",\"AncillaryKeywords\":[\"GHRSST\",\"sea
+        surface temperature\",\"Level 4\",\"SST\",\"surface temperature\",\" MUR\",\"
+        foundation SST\",\" SST anomaly\",\" anomaly\"],\"CollectionCitations\":[{\"Creator\":\"JPL
+        MUR MEaSUREs Project\",\"OnlineResource\":{\"Linkage\":\"https://podaac.jpl.nasa.gov/MEaSUREs-MUR\"},\"Publisher\":\"JPL
+        NASA\",\"Title\":\"GHRSST Level 4 MUR Global Foundation Sea Surface Temperature
+        Analysis\",\"SeriesName\":\"GHRSST Level 4 MUR Global Foundation Sea Surface
+        Temperature Analysis\",\"OtherCitationDetails\":\"JPL MUR MEaSUREs Project,
+        JPL NASA, 2015-03-11, GHRSST Level 4 MUR Global Foundation Sea Surface Temperature
+        Analysis (v4.1)\",\"ReleaseDate\":\"2015-03-11T00:00:00.000Z\",\"Version\":\"4.1\",\"ReleasePlace\":\"Jet
+        Propulsion Laboratory\"}],\"AdditionalAttributes\":[{\"DataType\":\"DATETIME\",\"Description\":\"Earliest
+        Granule Start Time for dataset.\",\"Name\":\"earliest_granule_start_time\",\"Value\":\"2002-06-01T09:00:00.000Z\"},{\"DataType\":\"DATETIME\",\"Description\":\"Latest
+        Granule Stop/End Time for dataset.\",\"Name\":\"latest_granule_end_time\",\"Value\":\"2021-01-25T09:00:00.000Z\"},{\"DataType\":\"STRING\",\"Description\":\"Dataset
+        citation series name\",\"Name\":\"Series Name\",\"Value\":\"GHRSST Level 4
+        MUR Global Foundation Sea Surface Temperature Analysis\"},{\"DataType\":\"STRING\",\"Description\":\"Dataset
+        Persistent ID\",\"Name\":\"Persistent ID\",\"Value\":\"PODAAC-GHGMR-4FJ04\"}],\"SpatialExtent\":{\"GranuleSpatialRepresentation\":\"CARTESIAN\",\"HorizontalSpatialDomain\":{\"Geometry\":{\"BoundingRectangles\":[{\"EastBoundingCoordinate\":180,\"NorthBoundingCoordinate\":90,\"SouthBoundingCoordinate\":-90,\"WestBoundingCoordinate\":-180}],\"CoordinateSystem\":\"CARTESIAN\"},\"ResolutionAndCoordinateSystem\":{\"Description\":\"Projection
+        Type: Cylindrical Lat-Lon, Projection Detail: Geolocation information included
+        for each pixel\",\"GeodeticModel\":{\"DenominatorOfFlatteningRatio\":298.2572236,\"EllipsoidName\":\"WGS
+        84\",\"HorizontalDatumName\":\"World Geodetic System 1984\",\"SemiMajorAxis\":6378137},\"HorizontalDataResolution\":{\"GenericResolutions\":[{\"Unit\":\"Decimal
+        Degrees\",\"XDimension\":0.01,\"YDimension\":0.01}]}}},\"SpatialCoverageType\":\"HORIZONTAL\"},\"CollectionProgress\":\"ACTIVE\",\"StandardProduct\":false,\"ScienceKeywords\":[{\"Category\":\"EARTH
+        SCIENCE\",\"DetailedVariable\":\"FOUNDATION SEA SURFACE TEMPERATURE\",\"Term\":\"OCEAN
+        TEMPERATURE\",\"Topic\":\"OCEANS\",\"VariableLevel1\":\"SEA SURFACE TEMPERATURE\"}],\"TemporalExtents\":[{\"RangeDateTimes\":[{\"BeginningDateTime\":\"2002-05-31T21:00:00.000Z\"}]}],\"ProcessingLevel\":{\"Id\":\"4\",\"ProcessingLevelDescription\":\"Level
+        4  following GHRSST Data Specification\"},\"DOI\":{\"Authority\":\"https://doi.org\",\"DOI\":\"10.5067/GHGMR-4FJ04\"},\"ShortName\":\"MUR-JPL-L4-GLOB-v4.1\",\"EntryTitle\":\"GHRSST
+        Level 4 MUR Global Foundation Sea Surface Temperature Analysis (v4.1)\",\"PublicationReferences\":[{\"Author\":\"Chin,
+        T.M,  J. Vazquez-Cuervo, and E.M. Armstrong\",\"DOI\":{\"DOI\":\"https://doi.org/10.1016/j.rse.2017.07.029\\r\\n\"},\"Pages\":\"154-169\",\"PublicationDate\":\"2017-10-01T00:00:00.000Z\",\"Publisher\":\"Remote
+        Sensing of Environment \",\"Title\":\" A multi-scale high-resolution analysis
+        of global sea surface temperature\",\"Volume\":\"200 \"}],\"DirectDistributionInformation\":{\"Region\":\"us-west-2\",\"S3BucketAndObjectPrefixNames\":[\"podaac-ops-cumulus-public/MUR-JPL-L4-GLOB-v4.1/\",\"podaac-ops-cumulus-protected/MUR-JPL-L4-GLOB-v4.1/\"],\"S3CredentialsAPIDocumentationURL\":\"https://archive.podaac.earthdata.nasa.gov/s3credentialsREADME\",\"S3CredentialsAPIEndpoint\":\"https://archive.podaac.earthdata.nasa.gov/s3credentials\"},\"RelatedUrls\":[{\"Description\":\"Data
+        Use and Citation Guidelines\",\"Subtype\":\"DATA CITATION GUIDELINES\",\"Type\":\"VIEW
+        RELATED INFORMATION\",\"URL\":\"https://podaac.jpl.nasa.gov/CitingPODAAC\",\"URLContentType\":\"PublicationURL\"},{\"Description\":\"Group
+        for High Resolution Sea Surface Temperature Information\",\"Subtype\":\"GENERAL
+        DOCUMENTATION\",\"Type\":\"VIEW RELATED INFORMATION\",\"URL\":\"https://ghrsst.jpl.nasa.gov\",\"URLContentType\":\"PublicationURL\"},{\"Description\":\"Homepage
+        for the NASA MEaSUREs projects\",\"Subtype\":\"GENERAL DOCUMENTATION\",\"Type\":\"VIEW
+        RELATED INFORMATION\",\"URL\":\"https://earthdata.nasa.gov/esds/competitive-programs/measures/mur-sst\",\"URLContentType\":\"PublicationURL\"},{\"Description\":\"Chin
+        T.M., Milliff R.F., Large W.G. (1998). Basin-scale, high-wavenumber sea surface
+        wind fields from a multiresolution analysis of scatterometer data. Journal
+        of Atmospheric and Oceanic Technology, 15: 741-763\",\"Subtype\":\"PUBLICATIONS\",\"Type\":\"VIEW
+        RELATED INFORMATION\",\"URL\":\"http://journals.ametsoc.org/doi/abs/10.1175/1520-0426%281998%29015%3C0741:BSHWSS%3E2.0.CO;2\",\"URLContentType\":\"PublicationURL\"},{\"Description\":\"Documentation
+        on the GDS version 2 format specification\",\"Subtype\":\"USER'S GUIDE\",\"Type\":\"VIEW
+        RELATED INFORMATION\",\"URL\":\"https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-docs/ghrsst/open/docs/GDS20r5.pdf\",\"URLContentType\":\"PublicationURL\"},{\"Description\":\"Generic
+        data readers\",\"Subtype\":\"DATA RECIPE\",\"Type\":\"VIEW RELATED INFORMATION\",\"URL\":\"https://github.com/podaac/data-readers\",\"URLContentType\":\"PublicationURL\"},{\"Description\":\"Chin,
+        Toshio Michael, Jorge Vazquez-Cuervo, and Edward M. Armstrong. A multi-scale
+        high-resolution analysis of global sea surface temperature. Remote sensing
+        of environment 200 (2017): 154-169.\",\"Subtype\":\"PUBLICATIONS\",\"Type\":\"VIEW
+        RELATED INFORMATION\",\"URL\":\"https://doi.org/10.1016/j.rse.2017.07.029\",\"URLContentType\":\"PublicationURL\"},{\"Description\":\"GHRSST
+        Project website\",\"Subtype\":\"GENERAL DOCUMENTATION\",\"Type\":\"VIEW RELATED
+        INFORMATION\",\"URL\":\"http://www.ghrsst.org\",\"URLContentType\":\"PublicationURL\"},{\"Description\":\"HTTPS
+        endpoint for data browse and download\",\"GetData\":{\"Format\":\"netCDF-4
+        classic\",\"MimeType\":\"application/x-netcdf\",\"Size\":300,\"Unit\":\"MB\"},\"Subtype\":\"DIRECT
+        DOWNLOAD\",\"Type\":\"GET DATA\",\"URL\":\"https://cmr.earthdata.nasa.gov/virtual-directory/collections/C1996881146-POCLOUD
+        \",\"URLContentType\":\"DistributionURL\"},{\"Description\":\"Browse granule
+        search results in Earthdata Search\",\"GetData\":{\"Format\":\"netCDF-4 classic\",\"MimeType\":\"application/x-netcdf\",\"Size\":700,\"Unit\":\"MB\"},\"Subtype\":\"Earthdata
+        Search\",\"Type\":\"GET DATA\",\"URL\":\" https://search.earthdata.nasa.gov/search/granules?p=C1996881146-POCLOUD
+        \",\"URLContentType\":\"DistributionURL\"},{\"Description\":\"MUR Project
+        homepage\",\"Subtype\":\"GENERAL DOCUMENTATION\",\"Type\":\"VIEW RELATED INFORMATION\",\"URL\":\"https://podaac.jpl.nasa.gov/MEaSUREs-MUR\",\"URLContentType\":\"PublicationURL\"},{\"Description\":\"Jupyter
+        python notebook to co-locate MUR and MODIS L2P satellite data with  Argo in-situ
+        data for cross-validation\",\"Subtype\":\"DATA RECIPE\",\"Type\":\"VIEW RELATED
+        INFORMATION\",\"URL\":\"https://github.com/podaac/tutorials/blob/master/notebooks/SWOT-EA-2021/Colocate_satellite_insitu_ocean.ipynb\",\"URLContentType\":\"PublicationURL\"},{\"Description\":\"SOTO
+        (State of the Ocean) Visualization\",\"Subtype\":\"SOTO\",\"Type\":\"GET RELATED
+        VISUALIZATION\",\"URL\":\"https://soto.podaac.earthdatacloud.nasa.gov/?l=GHRSST_L4_MUR_Sea_Surface_Temperature,BlueMarble_ShadedRelief_Bathymetry,Coastlines_15m\",\"URLContentType\":\"VisualizationURL\"},{\"Description\":\"Virtual
+        data set reference file for first decade of MUR record in JSON (experimental)\",\"Subtype\":\"VIRTUAL
+        COLLECTION\",\"Type\":\"GET DATA\",\"URL\":\"https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-docs/ghrsst/open/docs/MUR-JPL-L4-GLOB-v4.1_combined-ref.json\",\"URLContentType\":\"DistributionURL\"},{\"Description\":\"Virtual
+        data set reference file for first decade of MUR record in PARQUET (experimental)\",\"Subtype\":\"VIRTUAL
+        COLLECTION\",\"Type\":\"GET DATA\",\"URL\":\"https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-docs/ghrsst/open/docs/MUR-JPL-L4-GLOB-v4.1_combined-ref.parq.zip\",\"URLContentType\":\"DistributionURL\"},{\"Description\":\"Thumbnail\",\"Type\":\"GET
+        RELATED VISUALIZATION\",\"URL\":\"https://podaac.jpl.nasa.gov/Podaac/thumbnails/MUR-JPL-L4-GLOB-v4.1.jpg\",\"URLContentType\":\"VisualizationURL\"}],\"DataDates\":[{\"Date\":\"2014-10-31T16:30:37.998Z\",\"Type\":\"CREATE\"},{\"Date\":\"2017-04-28T05:01:45.000Z\",\"Type\":\"UPDATE\"}],\"Abstract\":\"A
+        Group for High Resolution Sea Surface Temperature (GHRSST) Level 4 sea surface
+        temperature analysis produced as a retrospective dataset (four day latency)
+        and near-real-time dataset (one day latency) at the JPL Physical Oceanography
+        DAAC using wavelets as basis functions in an optimal interpolation approach
+        on a global 0.01 degree grid. The version 4 Multiscale Ultrahigh Resolution
+        (MUR) L4 analysis is based upon nighttime GHRSST L2P skin and subskin SST
+        observations from several instruments including the NASA Advanced Microwave
+        Scanning Radiometer-EOS (AMSR-E), the JAXA Advanced Microwave Scanning Radiometer
+        2 on GCOM-W1, the Moderate Resolution Imaging Spectroradiometers (MODIS) on
+        the NASA Aqua and Terra platforms, the US Navy microwave WindSat radiometer,
+        the Advanced Very High Resolution Radiometer (AVHRR) on several NOAA satellites,
+        and in situ SST observations from the NOAA iQuam project. The ice concentration
+        data are from the archives at the EUMETSAT Ocean and Sea Ice Satellite Application
+        Facility (OSI SAF) High Latitude Processing Center and are also used for an
+        improved SST parameterization for the high-latitudes.  The dataset also contains
+        additional variables for some granules including a SST anomaly derived from
+        a MUR climatology and the temporal distance to the nearest IR measurement
+        for each pixel.This dataset is funded by the NASA MEaSUREs program ( http://earthdata.nasa.gov/our-community/community-data-system-programs/measures-projects
+        ), and created by a team led by Dr. Toshio M. Chin from JPL. It adheres to
+        the GHRSST Data Processing Specification (GDS) version 2 format specifications.
+        Use the file global metadata \\\"history:\\\" attribute to determine if a
+        granule is near-realtime or retrospective.\",\"LocationKeywords\":[{\"Category\":\"GEOGRAPHIC
+        REGION\",\"Type\":\"GLOBAL\"}],\"MetadataDates\":[{\"Date\":\"2021-04-07T16:30:00.000Z\",\"Type\":\"CREATE\"},{\"Date\":\"2023-05-30T16:42:00.000Z\",\"Type\":\"UPDATE\"}],\"Version\":\"4.1\",\"Projects\":[{\"LongName\":\"Group
+        for High Resolution Sea Surface Temperature\",\"ShortName\":\"GHRSST\"}],\"ContactPersons\":[{\"ContactInformation\":{\"ContactMechanisms\":[{\"Type\":\"Email\",\"Value\":\"toshio.m.chin@jpl.nasa.gov\"}]},\"FirstName\":\"Toshio\",\"LastName\":\"Chin\",\"MiddleName\":\"Mike\",\"NonDataCenterAffiliation\":\"NASA
+        Jet Propulsion Laboratory\",\"Roles\":[\"Science Contact\"]}],\"DataCenters\":[{\"ContactGroups\":[{\"ContactInformation\":{\"ContactMechanisms\":[{\"Type\":\"Email\",\"Value\":\"podaac@podaac.jpl.nasa.gov\"}],\"RelatedUrls\":[{\"Type\":\"HOME
+        PAGE\",\"URL\":\"https://podaac.jpl.nasa.gov/\",\"URLContentType\":\"DataContactURL\"}]},\"GroupName\":\"Help
+        Desk\",\"Roles\":[\"Data Center Contact\"]}],\"ContactInformation\":{\"ContactMechanisms\":[{\"Type\":\"Email\",\"Value\":\"podaac@podaac.jpl.nasa.gov\"}],\"RelatedUrls\":[{\"Type\":\"HOME
+        PAGE\",\"URL\":\"https://podaac.jpl.nasa.gov/\",\"URLContentType\":\"DataCenterURL\"}]},\"LongName\":\"Physical
+        Oceanography Distributed Active Archive Center, Jet Propulsion Laboratory,
+        NASA\",\"Roles\":[\"ARCHIVER\"],\"ShortName\":\"NASA/JPL/PODAAC\"},{\"ContactInformation\":{\"ContactMechanisms\":[{\"Type\":\"Email\",\"Value\":\"podaac@podaac.jpl.nasa.gov\"}],\"RelatedUrls\":[{\"Type\":\"HOME
+        PAGE\",\"URL\":\"https://podaac.jpl.nasa.gov/missions\",\"URLContentType\":\"DataCenterURL\"}]},\"LongName\":\"Jet
+        Propulsion Laboratory, NASA\",\"Roles\":[\"PROCESSOR\"],\"ShortName\":\"NASA/JPL\"},{\"ContactInformation\":{\"ContactMechanisms\":[{\"Type\":\"Email\",\"Value\":\"podaac@podaac.jpl.nasa.gov\"}],\"RelatedUrls\":[{\"Type\":\"HOME
+        PAGE\",\"URL\":\"https://podaac.jpl.nasa.gov/\",\"URLContentType\":\"DataCenterURL\"}]},\"LongName\":\"Physical
+        Oceanography Distributed Active Archive Center, Jet Propulsion Laboratory,
+        NASA\",\"Roles\":[\"DISTRIBUTOR\"],\"ShortName\":\"NASA/JPL/PODAAC\"}],\"TemporalKeywords\":[\"Hourly
+        - < Daily\"],\"Platforms\":[{\"Characteristics\":[{\"DataType\":\"FLOAT\",\"Description\":\"Nominal
+        period of a spacecraft\u2019s single revolution on an orbital plane.\",\"Name\":\"OrbitPeriod\",\"Unit\":\"Minutes\",\"Value\":\"98.4\"},{\"DataType\":\"FLOAT\",\"Description\":\"Spacecraft
+        angular distance from orbital plane relative to the Equator.\",\"Name\":\"InclinationAngle\",\"Unit\":\"Degrees\",\"Value\":\"98.1\"}],\"Instruments\":[{\"Characteristics\":[{\"DataType\":\"FLOAT\",\"Description\":\"Spacecraft
+        angular distance from orbital plane relative to the Equator.\",\"Name\":\"SwathWidth\",\"Unit\":\"Kilometers\",\"Value\":\"2330.0\"}],\"LongName\":\"Moderate-Resolution
+        Imaging Spectroradiometer\",\"ShortName\":\"MODIS\"},{\"Characteristics\":[{\"DataType\":\"FLOAT\",\"Description\":\"Spacecraft
+        angular distance from orbital plane relative to the Equator.\",\"Name\":\"SwathWidth\",\"Unit\":\"Kilometers\",\"Value\":\"1450.0\"}],\"LongName\":\"Advanced
+        Microwave Scanning Radiometer-EOS\",\"ShortName\":\"AMSR-E\"}],\"LongName\":\"Earth
+        Observing System, Aqua\",\"ShortName\":\"Aqua\",\"Type\":\"Earth Observation
+        Satellites\"},{\"Characteristics\":[{\"DataType\":\"FLOAT\",\"Description\":\"Nominal
+        period of a spacecraft\u2019s single revolution on an orbital plane.\",\"Name\":\"OrbitPeriod\",\"Unit\":\"Minutes\",\"Value\":\"101.6\"},{\"DataType\":\"FLOAT\",\"Description\":\"Spacecraft
+        angular distance from orbital plane relative to the Equator.\",\"Name\":\"InclinationAngle\",\"Unit\":\"Degrees\",\"Value\":\"98.7\"}],\"Instruments\":[{\"Characteristics\":[{\"DataType\":\"FLOAT\",\"Description\":\"Spacecraft
+        angular distance from orbital plane relative to the Equator.\",\"Name\":\"SwathWidth\",\"Unit\":\"Kilometers\",\"Value\":\"1200.0\"}],\"LongName\":\"WindSat\",\"ShortName\":\"WINDSAT\"}],\"LongName\":\"Coriolis\",\"ShortName\":\"CORIOLIS\",\"Type\":\"Earth
+        Observation Satellites\"},{\"Characteristics\":[{\"DataType\":\"FLOAT\",\"Description\":\"Nominal
+        period of a spacecraft\u2019s single revolution on an orbital plane.\",\"Name\":\"OrbitPeriod\",\"Unit\":\"Minutes\",\"Value\":\"98.8\"},{\"DataType\":\"FLOAT\",\"Description\":\"Spacecraft
+        angular distance from orbital plane relative to the Equator.\",\"Name\":\"InclinationAngle\",\"Unit\":\"Degrees\",\"Value\":\"98.2\"}],\"Instruments\":[{\"Characteristics\":[{\"DataType\":\"FLOAT\",\"Description\":\"Spacecraft
+        angular distance from orbital plane relative to the Equator.\",\"Name\":\"SwathWidth\",\"Unit\":\"Kilometers\",\"Value\":\"2330.0\"}],\"LongName\":\"Moderate-Resolution
+        Imaging Spectroradiometer\",\"ShortName\":\"MODIS\"}],\"LongName\":\"Earth
+        Observing System, Terra (AM-1)\",\"ShortName\":\"Terra\",\"Type\":\"Earth
+        Observation Satellites\"},{\"Characteristics\":[{\"DataType\":\"FLOAT\",\"Description\":\"Nominal
+        period of a spacecraft\u2019s single revolution on an orbital plane.\",\"Name\":\"OrbitPeriod\",\"Unit\":\"Minutes\",\"Value\":\"102.12\"},{\"DataType\":\"FLOAT\",\"Description\":\"Spacecraft
+        angular distance from orbital plane relative to the Equator.\",\"Name\":\"InclinationAngle\",\"Unit\":\"Degrees\",\"Value\":\"98.74\"}],\"Instruments\":[{\"Characteristics\":[{\"DataType\":\"FLOAT\",\"Description\":\"Spacecraft
+        angular distance from orbital plane relative to the Equator.\",\"Name\":\"SwathWidth\",\"Unit\":\"Kilometers\",\"Value\":\"2400.0\"}],\"LongName\":\"Advanced
+        Very High Resolution Radiometer-3\",\"ShortName\":\"AVHRR-3\"}],\"LongName\":\"National
+        Oceanic & Atmospheric Administration-19\",\"ShortName\":\"NOAA-19\",\"Type\":\"Earth
+        Observation Satellites\"},{\"Characteristics\":[{\"DataType\":\"FLOAT\",\"Description\":\"Nominal
+        period of a spacecraft\u2019s single revolution on an orbital plane.\",\"Name\":\"OrbitPeriod\",\"Unit\":\"Minutes\",\"Value\":\"100.0\"},{\"DataType\":\"FLOAT\",\"Description\":\"Spacecraft
+        angular distance from orbital plane relative to the Equator.\",\"Name\":\"InclinationAngle\",\"Unit\":\"Degrees\",\"Value\":\"98.19\"}],\"Instruments\":[{\"Characteristics\":[{\"DataType\":\"FLOAT\",\"Description\":\"Spacecraft
+        angular distance from orbital plane relative to the Equator.\",\"Name\":\"SwathWidth\",\"Unit\":\"Kilometers\",\"Value\":\"1450.0\"}],\"LongName\":\"Advanced
+        Microwave Scanning Radiometer 2\",\"ShortName\":\"AMSR2\"}],\"LongName\":\"Global
+        Change Observation Mission 1st-Water\",\"ShortName\":\"GCOM-W1\",\"Type\":\"Earth
+        Observation Satellites\"},{\"Instruments\":[{\"ShortName\":\"DRIFTING BUOYS\"}],\"ShortName\":\"BUOYS\",\"Type\":\"In
+        Situ Ocean-based Platforms\"}],\"MetadataSpecification\":{\"Name\":\"UMM-C\",\"URL\":\"https://cdn.earthdata.nasa.gov/umm/collection/v1.18.4\",\"Version\":\"1.18.4\"},\"ArchiveAndDistributionInformation\":{\"FileArchiveInformation\":[{\"AverageFileSize\":700,\"AverageFileSizeUnit\":\"MB\",\"Format\":\"netCDF-4\",\"FormatType\":\"Native\",\"TotalCollectionFileSizeBeginDate\":\"2002-06-01T00:00:00.000Z\"}],\"FileDistributionInformation\":[{\"AverageFileSize\":700,\"AverageFileSizeUnit\":\"MB\",\"Format\":\"netCDF-4\",\"FormatType\":\"Native\",\"TotalCollectionFileSizeBeginDate\":\"2002-06-01T00:00:00.000Z\"}]}}}]}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out,
+        CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+      CMR-Hits:
+      - '1'
+      CMR-Request-Id:
+      - b36ecc4f-e0eb-4015-91ea-073ea1a18cc1
+      CMR-Search-After:
+      - '[0.0,8400.0,"MUR-JPL-L4-GLOB-v4.1","4.1",1238621141,1115]'
+      CMR-Took:
+      - '11'
+      Connection:
+      - keep-alive
+      Content-MD5:
+      - d61ec45d16eab4b5a8d6f6bac2a65c6b
+      Content-SHA1:
+      - a71263ed976793311e0bf7872912a3cd8e9970bf
+      Content-Type:
+      - application/vnd.nasa.cmr.umm_results+json;version=1.18.4; charset=utf-8
+      Date:
+      - Mon, 11 Aug 2025 19:58:11 GMT
+      Server:
+      - ServerTokens ProductOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 1350a036cede21cb668ee0a3279a5c4c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Whi6SSjeWEiGJHyqNQkv_pllnbQI02DF58KHhg-Pope0U87UPcbTmA==
+      X-Amz-Cf-Pop:
+      - LAX53-P2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - Whi6SSjeWEiGJHyqNQkv_pllnbQI02DF58KHhg-Pope0U87UPcbTmA==
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '17642'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_get_collection_concept_id/test_get_collection_concept_id[PREFIRE_SAT2_2B-FLX_COG].yaml
+++ b/tests/cassettes/test_get_collection_concept_id/test_get_collection_concept_id[PREFIRE_SAT2_2B-FLX_COG].yaml
@@ -1,0 +1,157 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.4
+    method: GET
+    uri: https://cmr.uat.earthdata.nasa.gov/search/collections.umm_json?provider=LARC_CLOUD&short_name=PREFIRE_SAT2_2B-FLX_COG&version=R01
+  response:
+    body:
+      string: "{\"hits\":1,\"took\":10,\"items\":[{\"meta\":{\"revision-id\":5,\"deleted\":false,\"format\":\"application/vnd.nasa.cmr.umm+json\",\"provider-id\":\"LARC_CLOUD\",\"has-combine\":false,\"user-id\":\"userexample\",\"has-formats\":true,\"associations\":{\"variables\":[\"V1270130943-LARC_CLOUD\"],\"services\":[\"S1257776354-EEDTEST\"]},\"s3-links\":[\"s3://asdc-prod-protected/PREFIRE/PREFIRE_SAT2_2B-FLX_COG_R01\"],\"has-spatial-subsetting\":false,\"native-id\":\"MMT_a95a070e-9d29-47af-b828-33b31ab09b74\",\"has-transforms\":true,\"association-details\":{\"variables\":[{\"concept-id\":\"V1270130943-LARC_CLOUD\"}],\"services\":[{\"concept-id\":\"S1257776354-EEDTEST\"}]},\"has-variables\":true,\"concept-id\":\"C1273150419-LARC_CLOUD\",\"revision-date\":\"2025-04-11T15:00:34.487Z\",\"has-temporal-subsetting\":false,\"concept-type\":\"collection\"},\"umm\":{\"DataLanguage\":\"eng\",\"AdditionalAttributes\":[{\"Name\":\"CUMULUS\",\"Description\":\"Cumulus
+        flag\",\"DataType\":\"BOOLEAN\"}],\"SpatialExtent\":{\"HorizontalSpatialDomain\":{\"Geometry\":{\"BoundingRectangles\":[{\"EastBoundingCoordinate\":180,\"NorthBoundingCoordinate\":90,\"SouthBoundingCoordinate\":-90,\"WestBoundingCoordinate\":-180}],\"CoordinateSystem\":\"GEODETIC\"},\"ResolutionAndCoordinateSystem\":{\"HorizontalDataResolution\":{\"VariesResolution\":\"Varies\"}}},\"SpatialCoverageType\":\"HORIZONTAL\",\"GranuleSpatialRepresentation\":\"GEODETIC\"},\"CollectionProgress\":\"PLANNED\",\"StandardProduct\":false,\"ScienceKeywords\":[{\"Category\":\"EARTH
+        SCIENCE\",\"Topic\":\"ATMOSPHERE\",\"Term\":\"ATMOSPHERIC RADIATION\",\"VariableLevel1\":\"RADIATIVE
+        FLUX\"},{\"Category\":\"EARTH SCIENCE\",\"Topic\":\"ATMOSPHERE\",\"Term\":\"ATMOSPHERIC
+        RADIATION\",\"VariableLevel1\":\"EARTH RADIATION BUDGET\"},{\"Category\":\"EARTH
+        SCIENCE\",\"Topic\":\"ATMOSPHERE\",\"Term\":\"ATMOSPHERIC RADIATION\",\"VariableLevel1\":\"OUTGOING
+        LONGWAVE RADIATION\"},{\"Category\":\"EARTH SCIENCE\",\"Topic\":\"ATMOSPHERE\",\"Term\":\"ATMOSPHERIC
+        RADIATION\",\"VariableLevel1\":\"LONGWAVE RADIATION\",\"VariableLevel2\":\"UPWELLING
+        LONGWAVE RADIATION\"}],\"TemporalExtents\":[{\"RangeDateTimes\":[{\"BeginningDateTime\":\"2024-06-29T00:00:00.000Z\"}],\"PrecisionOfSeconds\":3,\"EndsAtPresentFlag\":true}],\"ProcessingLevel\":{\"Id\":\"2\",\"ProcessingLevelDescription\":\"Result
+        of analysis of lower level data\"},\"DOI\":{\"Authority\":\"https://doi.org/\",\"DOI\":\"10.5067/PREFIRE-SAT2/PREFIRE/FLX_COG_L2B.R01\"},\"ShortName\":\"PREFIRE_SAT2_2B-FLX_COG\",\"EntryTitle\":\"Polar
+        Radiant Energy in the Far InfraRed Experiment (PREFIRE) Spectral Flux from
+        PREFIRE Satellite 2 COG R01\",\"PublicationReferences\":[{\"OnlineResource\":{\"Name\":\"American
+        Meteorological Society\",\"Linkage\":\"https://journals.ametsoc.org/view/journals/bams/102/7/BAMS-D-20-0155.1.xml\",\"Protocol\":\"https\",\"MimeType\":\"application/pdf\"},\"Volume\":\"102\",\"Publisher\":\"American
+        Meteorological Society\",\"Title\":\"The Polar Radiant Energy in the Far InfraRed
+        Experiment: A New Perspective on Polar Longwave Energy Exchanges\",\"DOI\":{\"DOI\":\"https://doi.org/10.1175/BAMS-D-20-0155.1\"},\"Issue\":\"7\",\"PublicationDate\":\"2021-07-01T00:00:00.000Z\",\"Author\":\"L'Ecuyer,T.S,
+        B.J. Drouin, J. Anheuser, M. Grames, D. Henderson, X. Huang, B.H. Kahn, J.E.
+        Kay, B.H. Lim, M. Mateling, A. Merelli, N.B. Miller, S. Padmanabhan, C. Peterson,
+        N. Schlegel, M.L. White, and Y Xie\",\"OtherReferenceDetails\":\"Boston, MA\",\"Series\":\"Bulletin
+        of the American Meteorological Society\",\"Pages\":\"E1431-E1449\"}],\"DirectDistributionInformation\":{\"S3BucketAndObjectPrefixNames\":[\"s3://asdc-prod-protected/PREFIRE/PREFIRE_SAT2_2B-FLX_COG_R01\"],\"Region\":\"us-west-2\",\"S3CredentialsAPIEndpoint\":\"https://data.asdc.uat.earthdata.nasa.gov/s3credentials\",\"S3CredentialsAPIDocumentationURL\":\"https://data.asdc.uat.earthdata.nasa.gov/s3credentialsREADME\"},\"AccessConstraints\":{\"Value\":4,\"Description\":\"WORLD\"},\"MetadataLanguage\":\"eng\",\"RelatedUrls\":[{\"Description\":\"Mission
+        Logo\",\"URLContentType\":\"VisualizationURL\",\"Type\":\"GET RELATED VISUALIZATION\",\"Subtype\":\"WORLDVIEW\",\"URL\":\"https://asdc.larc.nasa.gov/static/images/project_logos/prefire.png\"},{\"Description\":\"PREFIRE
+        Data Set Landing Page ASDC\",\"URLContentType\":\"CollectionURL\",\"Type\":\"DATA
+        SET LANDING PAGE\",\"URL\":\"https://asdc.larc.nasa.gov/project/PREFIRE\"},{\"Description\":\"NASA
+        JPL PREFIRE Project Page\",\"URLContentType\":\"CollectionURL\",\"Type\":\"PROJECT
+        HOME PAGE\",\"URL\":\"https://science.jpl.nasa.gov/projects/prefire/\"},{\"Description\":\"University
+        of Wisconsin PREFIRE Project Page\",\"URLContentType\":\"CollectionURL\",\"Type\":\"PROFESSIONAL
+        HOME PAGE\",\"URL\":\"https://prefire.ssec.wisc.edu/\"}],\"Abstract\":\"Polar
+        Radiant Energy in the Far InfraRed Experiment (PREFIRE) Spectral Flux from
+        PREFIRE Satellite 2 (PREFIRE_SAT2_2B-FLX) contains surface emissivity derived
+        from data collected by the PREFIRE Thermal Infrared Spectrometer (TIRS-PREFIRE)
+        aboard PREFIRE-SAT2. Duel CubeSats each carry a PREFIRE Thermal Infrared Spectrometer
+        (TIRS-PREFIRE), a push broom spectrometer with 63 channels measuring mid-
+        and far-infrared (FIR) radiation from approximately 5 to 53 \xB5m. Most polar
+        emissions are in the FIR but have not been measured on a large scale. PREFIRE
+        aims to fill knowledge gaps in the global energy budget by more accurately
+        characterizing polar emissions. This information will then be assimilated
+        into global circulation and other climate models to predict future climates
+        more accurately.\\r\\n\\r\\nPREFIRE_SAT2_2B-FLX contains spectral flux at
+        the top of the atmosphere for all available TIRS-PREFIRE channels as derived
+        from PREFIRE Spectral Radiance (PREFIRE_SAT2_1B-RAD) data using an Optimal
+        Estimation retrieval with inputs from the PREFIRE_SAT2_2B-MSK (cloud mask),
+        PREFIRE_SAT2_AUX-MET (Auxiliary Meteorology), and PREFIRE_SAT2_AUX-SAT collections.
+        PREFIRE_SAT2_2B-FLX also contains the top-of-atmosphere Outgoing Longwave
+        Radiation (OLR) broadband flux.  \\r\\nThe primary purpose of this collection
+        is to assess the radiative activities over the polar regions to better quantify
+        the energy budget in those regions.\\r\\n\\r\\nData retrieval started in May
+        TBD, 2024, and is ongoing. Geographic coverage is global, with the greatest
+        concentration of data in the polar regions. The data swath is TBD km wide,
+        with 8 discrete TBD km wide data tracks corresponding to the 8 TIRS sensors.
+        Individual data footprints are TBD km long by TBD km wide. This data has a
+        temporal resolution of 0.707 seconds and is available in netCDF-4.\\r\\n\\r\\nThe
+        spectral flux data for the sister instrument aboard PREFIRE-SAT1 can be found
+        in the PREFIRE_SAT1_2B-FLX collection.\\r\\n\",\"Purpose\":\"PREFIRE_SAT2_2B-FLX_COG
+        will be used to study radiative balance in the polar regions.\\n\",\"LocationKeywords\":[{\"Category\":\"GEOGRAPHIC
+        REGION\",\"Type\":\"GLOBAL\"}],\"MetadataDates\":[{\"Type\":\"CREATE\",\"Date\":\"2024-07-01T15:29:00.000Z\"},{\"Type\":\"UPDATE\",\"Date\":\"2024-07-01T15:29:00.000Z\"}],\"MetadataAssociations\":[{\"Type\":\"INPUT\",\"EntryId\":\"PREFIRE_SAT2_AUX-MET\",\"Description\":\"PREFIRE_SAT2_AUX-MET
+        is a collection of analysis and satellite data that provides essential information
+        used to process Level 1B PREFIRE data to Level 2 products.\",\"Version\":\"R00\"},{\"Type\":\"INPUT\",\"EntryId\":\"PREFIRE_SAT2_1B-RAD\",\"Description\":\"This
+        product is derived from mid and far-infrared data contained in PREFIRE_SAT2_1B-RAD.\",\"Version\":\"R00\"},{\"Type\":\"INPUT\",\"EntryId\":\"PREFIRE_SAT1_2B-MSK\",\"Description\":\"PREFIRE_SAT1_2B-MSK
+        is used to identify clear an cloudy scenes.\",\"Version\":\"R00\"},{\"Type\":\"INPUT\",\"EntryId\":\"PREFIRE_SAT2_2B-CLD\",\"Description\":\"PREFIRE_SAT2_2B-CLD
+        provides cloud properties inputs for PREFIRE_SAT2_2B-FLX cloudy sky flux calculations.\",\"Version\":\"R00\"}],\"VersionDescription\":\"Initial
+        processing\",\"Version\":\"R01\",\"Projects\":[{\"Campaigns\":[\"PREFIRE\"],\"ShortName\":\"PREFIRE\",\"LongName\":\"Polar
+        Radiant Energy in the Far-InfraRed Experiment\"}],\"UseConstraints\":{\"LicenseURL\":{\"Linkage\":\"https://www.earthdata.nasa.gov/engage/open-data-services-software-policies/data-use-guidance\",\"Name\":\"Data
+        Use Guidance\",\"Description\":\"The Earth Observing System Data and Information
+        System (EOSDIS) data use guidance for NASA data.\"},\"FreeAndOpenData\":true},\"ContactPersons\":[{\"Roles\":[\"Technical
+        Contact\"],\"FirstName\":\"Erin \",\"LastName\":\"Hokanson Wagner\",\"ContactInformation\":{\"ServiceHours\":\"9am
+        - 4pm M-F\",\"ContactInstruction\":\"This is a group admin email.  The appropriate
+        party will be assigned to your inquiry.\",\"ContactMechanisms\":[{\"Type\":\"Email\",\"Value\":\"prefire-sdps.admin@office365.wisc.edu\"}],\"Addresses\":[{\"Country\":\"United
+        States\",\"StreetAddresses\":[\"Space Science and Engineering Center, University
+        of Wisconsin-Madison\",\"1225 West Dayton Street\"],\"City\":\"Madison\",\"PostalCode\":\"53706\"}]}}],\"CollectionDataType\":\"OTHER\",\"DataCenters\":[{\"Roles\":[\"ARCHIVER\"],\"ShortName\":\"NASA/LARC/SD/ASDC\",\"LongName\":\"Atmospheric
+        Science Data Center, Science Directorate, Langley Research Center, NASA\",\"ContactInformation\":{\"RelatedUrls\":[{\"URLContentType\":\"DataCenterURL\",\"Type\":\"HOME
+        PAGE\",\"URL\":\"https://asdc.larc.nasa.gov/\"}]},\"ContactGroups\":[{\"Roles\":[\"Data
+        Center Contact\"],\"GroupName\":\"ASDC USER SERVICES\",\"ContactInformation\":{\"ContactMechanisms\":[{\"Type\":\"Email\",\"Value\":\"support-asdc@earthdata.nasa.gov\"}],\"Addresses\":[{\"Country\":\"United
+        States\",\"StreetAddresses\":[\"NASA Langley Atmospheric Science Data Center\",\"User
+        and Data Services\",\"NASA Langley Research Center\"],\"City\":\"Hampton\",\"StateProvince\":\"Virginia\",\"PostalCode\":\"23681-2199\"}],\"RelatedUrls\":[{\"URLContentType\":\"DataContactURL\",\"Type\":\"HOME
+        PAGE\",\"URL\":\"https://asdc.larc.nasa.gov/\"}]}}]}],\"TemporalKeywords\":[\"<
+        1 second\"],\"Platforms\":[{\"Characteristics\":[{\"Name\":\"Satellite type\",\"Description\":\"Type
+        of CubeSat body.  In this case, the body is comprised of 6 basic CubeSat units.\",\"Value\":\"6\",\"Unit\":\"Unit\",\"DataType\":\"INT\"},{\"Name\":\"Length\",\"Description\":\"Length
+        of CubeSat body, not including solar panels\",\"Value\":\"300\",\"Unit\":\"cm\",\"DataType\":\"FLOAT\"},{\"Name\":\"Width\",\"Description\":\"Width
+        of CubeSat body, not including solar panels.\",\"Value\":\"200\",\"Unit\":\"cm\",\"DataType\":\"FLOAT\"},{\"Name\":\"Depth\",\"Description\":\"Depth
+        of CubeSat body, not including solar panels.\",\"Value\":\"100\",\"Unit\":\"cm\",\"DataType\":\"FLOAT\"}],\"Instruments\":[{\"Characteristics\":[{\"Name\":\"Minimum
+        wavelength\",\"Description\":\"Minimum usable wavelength measured by the instrument\",\"Value\":\"4.64\",\"Unit\":\"\xB5m\",\"DataType\":\"FLOAT\"},{\"Name\":\"Maximum
+        wavelength\",\"Description\":\"Maximum wavelength\",\"Value\":\"52.74\",\"Unit\":\"\xB5m\",\"DataType\":\"FLOAT\"}],\"ShortName\":\"TIRS-PREFIRE\",\"LongName\":\"Thermal
+        InfraRed Spectrometer\",\"Technique\":\"Thermal Infrared Spectrometer - Polar
+        Radiant Energy in the Far Infrared Experiment\",\"NumberOfInstruments\":1}],\"Type\":\"Earth
+        Observation Satellites\",\"ShortName\":\"PREFIRE-SAT2\",\"LongName\":\"Polar
+        Radiant Energy in the Far InfraRed Experiment (PREFIRE) Satellite-2\"}],\"MetadataSpecification\":{\"URL\":\"https://cdn.earthdata.nasa.gov/umm/collection/v1.18.4\",\"Name\":\"UMM-C\",\"Version\":\"1.18.4\"},\"ArchiveAndDistributionInformation\":{\"FileArchiveInformation\":[{\"Format\":\"netCDF-4\",\"FormatType\":\"Native\",\"FormatDescription\":\"Files
+        are moderately self-describing via their internal metadata.\",\"AverageFileSize\":3.7,\"AverageFileSizeUnit\":\"MB\"}],\"FileDistributionInformation\":[{\"Format\":\"netCDF-4\",\"FormatType\":\"Native\",\"FormatDescription\":\"Files
+        are moderately self-describing via their internal metadata.\",\"AverageFileSize\":3.7,\"AverageFileSizeUnit\":\"MB\"}]}}}]}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out,
+        CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+      CMR-Hits:
+      - '1'
+      CMR-Request-Id:
+      - b5925ce6-21ce-4075-96ba-261279a5a84e
+      CMR-Search-After:
+      - '[0.0,0.0,"PREFIRE_SAT2_2B-FLX_COG","r01",1273150419,5]'
+      CMR-Took:
+      - '11'
+      Connection:
+      - keep-alive
+      Content-MD5:
+      - 30a987cfe6bebf7e594938ae4c4136a1
+      Content-SHA1:
+      - 03b4fc9105ce9be22b33d53412ed24656c2e6b40
+      Content-Type:
+      - application/vnd.nasa.cmr.umm_results+json;version=1.18.4; charset=utf-8
+      Date:
+      - Mon, 11 Aug 2025 19:58:10 GMT
+      Server:
+      - ServerTokens ProductOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 e1781e38c27c8587a4a79b775f1d6666.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Uii-xcPPXs4arScWl7fpcmKFbmQoqbl5ZQTq-q4M0-uQEVdeomMEcQ==
+      X-Amz-Cf-Pop:
+      - LAX53-P2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - Uii-xcPPXs4arScWl7fpcmKFbmQoqbl5ZQTq-q4M0-uQEVdeomMEcQ==
+      X-XSS-Protection:
+      - 1; mode=block
+      content-length:
+      - '11159'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_get_collection_concept_id.py
+++ b/tests/test_get_collection_concept_id.py
@@ -1,0 +1,21 @@
+import pytest
+from bignbit.get_collection_concept_id import get_collection_concept_id
+
+
+@pytest.fixture(scope="session")
+def vcr_config():
+    return {"filter_headers": ["authorization"], "decode_compressed_response": True}
+
+@pytest.mark.vcr
+@pytest.mark.parametrize("collection_shortname, collection_version, collection_provider, expected_concept_id", [
+    ("PREFIRE_SAT2_2B-FLX_COG", "R01", "LARC_CLOUD", "C1273150419-LARC_CLOUD"),
+    ("MUR-JPL-L4-GLOB-v4.1", "4.1", "POCLOUD", "C1238621141-POCLOUD")
+], ids=["PREFIRE_SAT2_2B-FLX_COG", "MUR-JPL-L4-GLOB-v4.1"])
+def test_get_collection_concept_id(collection_shortname, collection_version, collection_provider, expected_concept_id, monkeypatch):
+
+    monkeypatch.setattr('bignbit.utils.get_edl_creds', lambda: (None, None))
+    monkeypatch.setattr('bignbit.utils.get_cmr_user_token', lambda *args: None)
+
+    concept_id = get_collection_concept_id(collection_shortname, collection_version, collection_provider, "UAT")
+
+    assert expected_concept_id == concept_id


### PR DESCRIPTION
Github Issue: #89 

### Description

Fixed bug where querying CMR for a collection could result in multiple results because collection version was not included in the query. Fix is to include the version in the CMR query, which will now return only one result.

### Overview of work done

Added `version` to cmr query. 

### Overview of verification done

Introduced test case for get collection concept id, although it's utility is tenuous at best because it uses vcrpy to mock the CMR communication. I'm leaving it in because it does still verify that the request contains the parameters that we expect which provides a little bit of value.

### Overview of integration done

Ran test in podaac services SIT account using a granule from `MUR-JPL-L4-GLOB-v4.1`. The `Get Collection Concept Id` step completed successfully and correctly identified `"collection_concept_id": "C1238621141-POCLOUD"`

## PR checklist:

* [x] Linted
* [x] Updated unit tests
* [x] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_