### PR TITLE
Issues/96: Change delimiter used in cnm identifier to !

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
-- [issues/91](https://github.com/podaac/bignbit/issues/91): Fixed bug where the CNM collection name sent to GIBS included '/' characters when dealing with certain variables. This caused processing errors in GIBS, all collection names will now replace '/' with '_' before being sent to GIBS. 
+- [issues/91](https://github.com/podaac/bignbit/issues/91): Fixed bug where the CNM collection name sent to GIBS included '/' characters when dealing with certain variables. This caused processing errors in GIBS, all collection names will now replace '/' with '_' before being sent to GIBS.
+- [issues/96](https://github.com/podaac/bignbit/issues/96): Fixed bug causing GIBS responses to fail processing due to provider name containing an underscore `_` which collided with the delimiter used in CNM identifiers. The new delimiter for CNM identifier is now an exclamation mark `!`.
 ### Security
 
 ## [0.3.0]

--- a/bignbit/build_image_sets.py
+++ b/bignbit/build_image_sets.py
@@ -60,7 +60,7 @@ class ImageSetGenerator(Process):
 
             for big_image_set in image_sets:
                 pobit_image_set = ImageSet(
-                    name=big_image_set.name + '_' + cmr_concept_id,
+                    name=big_image_set.name + '!' + cmr_concept_id,
                     image=big_image_set.image,
                     image_metadata=big_image_set.image_metadata,
                     world_file=big_image_set.world_file)

--- a/bignbit/handle_gitc_response.py
+++ b/bignbit/handle_gitc_response.py
@@ -36,7 +36,7 @@ def handler(event, _):
         collection_name = message_body["collection"]
         cmr_env = os.environ['CMR_ENVIRONMENT']
 
-        granule_concept_id = gitc_id.rpartition('_')[-1]
+        granule_concept_id = gitc_id.rpartition('!')[-1]
         umm_json = utils.get_umm_json(granule_concept_id, cmr_env)
         granule_ur = umm_json['GranuleUR']
 

--- a/tests/test_send_to_gibs_moto.py
+++ b/tests/test_send_to_gibs_moto.py
@@ -115,6 +115,7 @@ def test_process_sends_message(fake_response_sqs_queue, mock_gitc_success, cnm_v
 
     gibs_cnm = json.loads(sent_messages[0].body)
     jsonschema.validate(gibs_cnm, cnm_v151_schema, format_checker=jsonschema.FormatChecker())
+    assert gibs_cnm['identifier'] == '20210102090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB-v02.0-fv04.1_analysed_sst_regridded_subsetted_2021002!G1240565717-POCUMULUS'
 
     response_messages = fake_response_sqs_queue.receive_messages(MaxNumberOfMessages=1, WaitTimeSeconds=5)
     gitc_cnmr = json.loads(response_messages[0].body)


### PR DESCRIPTION
Github Issue: #96

### Description

Fixed bug causing GIBS responses to fail processing due to provider name containing an underscore `_` which collided with the delimiter used in CNM identifiers. The new delimiter for CNM identifier is now an exclamation mark `!`.

### Overview of work done

- Updated send to gibs code to use `!` instead of `_` to append granule concept id to the CNM identifier
- Updated handle gibs response to partition on `!` instead of `_` when parsing granule concept id from the returned CNM identifier.
- Added assertion to test

### Overview of verification done

Ran tests and they passed with updated assertion that identifier contains `!`

### Overview of integration done

None

## PR checklist:

* [x] Linted
* [x] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_