### PR TITLE
Upgraded Terraform null provider to v3.2.0

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.2.0"
     }
   }
 }


### PR DESCRIPTION
This is to support deployments of bignbit (via cumulus-tf) on ARM-based Macs

Issue: https://jira.jpl.nasa.gov/browse/PODAAC-7031

### Description

This is to support deployments of uncompress_granlue_module (via cumulus-tf) on ARM-based Macs

### Overview of work done

Upgraded Terraform null provider to v3.2.0 in main.tf

### Overview of verification done

Usage of null provider v3.2.0 has been verified during deployment of Cumulus to Sandbox environment on an M1 Macbook

### Overview of integration done

N/A

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_