### PR TITLE
Issues/121

### DIFF
--- a/bignbit/image_set.py
+++ b/bignbit/image_set.py
@@ -47,12 +47,14 @@ def from_big_output(big_output: List[typing.Dict]) -> List[ImageSet]:
     image_sets = []
     for image in images:
         image_name = pathlib.Path(image['fileName']).stem
+        crs = image['output_crs']
 
         try:
             image_metadata = next(iter([g for g in big_output
                                         if g['type'] == 'metadata'
                                         and g.get('subtype', None) == 'ImageMetadata-v1.2'
-                                        and pathlib.Path(g['fileName']).stem == image_name]))
+                                        and pathlib.Path(g['fileName']).stem == image_name
+                                        and g.get('output_crs', None) == crs]))
         except StopIteration as ex:
             raise IncompleteImageSet(f"Missing image metadata for {image}") from ex
 
@@ -60,7 +62,8 @@ def from_big_output(big_output: List[typing.Dict]) -> List[ImageSet]:
             world_file = next(iter([g for g in big_output
                                     if g['type'] == 'metadata'
                                     and g.get('subtype', None) == 'world file'
-                                    and pathlib.Path(g['fileName']).stem == image_name]))
+                                    and pathlib.Path(g['fileName']).stem == image_name
+                                    and g.get('output_crs', None) == crs]))
         except StopIteration:
             # World files are not always required
             world_file = {}


### PR DESCRIPTION
Github Issue: #121 

### Description

IBS has been attempting to validate the multi-projection support for bignbit intended for 0.4.0 (https://github.com/podaac/bignbit/pull/100 ) but they encountered a bug when ingesting polar-projected data sent by ASDC. Essentially, we are sending CNM messages where the PNG is in one projection, but the world file and metadata XML are in another projection. This was due to the image_set creation not matching PNGs with their ancillary files correctly when using the newly added multi-projection support feature. 

### Overview of work done

Modified the `from_bignbit_output` function used to create ImageSets, a class used internally to associate PNGs with their ancillary files and is eventually written out to the CNM messages sent to GIBS. This function will now match files on the `output_crs` key in the metadata, in addition to the other metadata we are already matching on.

### Overview of verification done

Unit tests passed. Additional testing will be performed after deploying this PR to SIT.

### Overview of integration done

Once we merge this PR into the release branch, we can create a new rc and do a full GIBS integration test with the PREFIRE data.

## PR checklist:

* [X] Linted
* [X] Updated unit tests (currently there are no unit tests for this section of the code, but I think that should be a separate ticket)
* [X] Updated changelog (N/A)
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_