### PR TITLE
test with null 2.1.0

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "> 2.1.0"
+      version = "> 2.1"
     }
   }
 }


### PR DESCRIPTION
### Description

This pull request includes a minor update to the Terraform provider version constraint for the `null` provider. The version constraint has been loosened to allow for a wider range of provider versions.

### Overview of work done

- updated the null provider so its less strict so allow anything above 2.1.0

### Overview of integration done

- tested with a cumulus deployment

_Explain how this change was integration tested. Provide screenshots or logs if appropriate._

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_