### PR TITLE
issue/164: Added granules to CMA payload for cumulus status reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- [issues/164](https://github.com/podaac/bignbit/issues/164): Add `granules` to payload output for cumulus db status reporting
 ### Security
 
 ## [0.7.0]

--- a/bignbit/handle_big_result.py
+++ b/bignbit/handle_big_result.py
@@ -171,7 +171,12 @@ class CMA(Process):
             })
             CUMULUS_LOGGER.info(f'Finished writing CNM message for {image_set.name}')
 
-        return {'pobit': pobit_cnm_urls}
+        response_payload = {
+            'granules': self.input.get('granules', []),
+            'pobit': pobit_cnm_urls,
+        }
+
+        return response_payload
 
 
 def process_harmony_results(harmony_job: dict[str, str], cmr_env: str) -> list[dict[str, Any]]:


### PR DESCRIPTION
Github Issue: #164 

### Description

Add `granules` field back in to CMA `payload` since it is used by cumulus [`sfEventSqsToDbRecords` lambda](https://github.com/nasa/cumulus/blob/master/tf-modules/archive/sf_event_sqs_to_db_records.tf) to determine if an ingest job is completed. 

### Overview of work done

Changed payload fields in Handle BIG result lambda.

### Overview of verification done

Unit tests passing

### Overview of integration done

Will test in SIT using a branch build to confirm no regressions.

## PR checklist:

* [X] Linted
* [ ] Updated unit tests
* [X] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_