### PR TITLE
issues/151: Added ExpectedBucketOwner parameter when making S3 requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
+- [issues/151](https://github.com/podaac/bignbit/issues/151): Added ExpectedBucketOwner parameter when making S3 requests.
 
 ## [0.7.2]
 ### Added

--- a/bignbit/get_dataset_configuration.py
+++ b/bignbit/get_dataset_configuration.py
@@ -9,6 +9,8 @@ import boto3
 from cumulus_logger import CumulusLogger
 from cumulus_process import Process
 
+from bignbit import utils
+
 CUMULUS_LOGGER = CumulusLogger('get_dataset_configuration')
 
 
@@ -69,7 +71,8 @@ def get_collection_config(config_bucket_name: str, config_key_name: str) -> dict
     s3_client = boto3.client('s3')
 
     try:
-        object_result = s3_client.get_object(Bucket=config_bucket_name, Key=config_key_name)
+        object_result = s3_client.get_object(Bucket=config_bucket_name, Key=config_key_name,
+                                             ExpectedBucketOwner=utils.get_aws_account_id())
     except s3_client.exceptions.NoSuchKey as ex:
         raise MissingDatasetConfiguration(
             f"Dataset configuration not found s3://{config_bucket_name}/{config_key_name}") from ex

--- a/bignbit/handle_big_result.py
+++ b/bignbit/handle_big_result.py
@@ -216,7 +216,8 @@ def process_harmony_results(harmony_job: dict[str, str], cmr_env: str) -> list[d
     for url in result_urls:
         bucket, key = urlparse(url).netloc, urlparse(url).path.lstrip('/')
 
-        response = s3_client.get_object(Bucket=bucket, Key=key)
+        response = s3_client.get_object(Bucket=bucket, Key=key,
+                                        ExpectedBucketOwner=utils.get_aws_account_id())
         md5_hash = hashlib.new('md5')
         for chunk in response['Body'].iter_chunks(chunk_size=100 * 1024 * 1024):  # 100 MB chunk size
             md5_hash.update(chunk)

--- a/bignbit/send_to_gitc.py
+++ b/bignbit/send_to_gitc.py
@@ -9,6 +9,8 @@ import boto3
 from cumulus_logger import CumulusLogger
 from cumulus_process import Process
 
+from bignbit import utils
+
 CUMULUS_LOGGER = CumulusLogger('send_to_gitc')
 
 GIBS_REGION_ENV_NAME = "GIBS_REGION"
@@ -72,7 +74,8 @@ def read_cnm(cnm_bucket: str, cnm_key: str) -> str:
       Key within the bucket pointing to CNM JSON
     """
     s3_client = boto3.client('s3')
-    response = s3_client.get_object(Bucket=cnm_bucket, Key=cnm_key)
+    response = s3_client.get_object(Bucket=cnm_bucket, Key=cnm_key,
+                                    ExpectedBucketOwner=utils.get_aws_account_id())
     return response['Body'].read().decode('utf-8')
 
 

--- a/bignbit/utils.py
+++ b/bignbit/utils.py
@@ -15,8 +15,25 @@ from harmony import Environment, Client
 ED_USER = ED_PASS = None
 EDL_USER_TOKEN: dict[str, str] = {}
 HARMONY_CLIENT: Client | None = None
+AWS_ACCOUNT_ID: str | None = None
 
 HARMONY_SHOULD_VALIDATE_AUTH = os.environ.get('HARMONY_SHOULD_VALIDATE_AUTH', default='False').upper() == 'TRUE'
+
+
+def get_aws_account_id() -> str:
+    """
+    Get and cache the current AWS account ID via STS.
+
+    Returns
+    -------
+    str
+        The AWS account ID for the current caller identity
+    """
+    global AWS_ACCOUNT_ID  # pylint: disable=W0603
+    if not AWS_ACCOUNT_ID:
+        sts_client = boto3.client('sts')
+        AWS_ACCOUNT_ID = sts_client.get_caller_identity()['Account']
+    return AWS_ACCOUNT_ID
 
 
 def get_edl_creds() -> tuple[str, str]:
@@ -215,7 +232,8 @@ def upload_string_as_object(bucket_name: str, key_name: str, object_content: str
     s3_client.put_object(
         Body=object_content.encode(),
         Bucket=bucket_name,
-        Key=key_name
+        Key=key_name,
+        ExpectedBucketOwner=get_aws_account_id()
     )
     return f's3://{bucket_name}/{key_name}'
 
@@ -235,6 +253,7 @@ def upload_object(
         Key=key,
         Body=body_content,
         ContentType=content_type,
+        ExpectedBucketOwner=get_aws_account_id()
     )
     return f's3://{bucket}/{key}'
 
@@ -258,7 +277,8 @@ def upload_to_s3(filepath: pathlib.Path, bucket_name: str, object_key: str):
       s3 uri of new object
     """
     s3_client = boto3.client('s3')
-    s3_client.upload_file(str(filepath), bucket_name, object_key)
+    s3_client.upload_file(str(filepath), bucket_name, object_key,
+                          ExtraArgs={'ExpectedBucketOwner': get_aws_account_id()})
 
     return f's3://{bucket_name}/{object_key}'
 

--- a/tests/test_handle_big_result.py
+++ b/tests/test_handle_big_result.py
@@ -4,7 +4,7 @@ import json
 import xml.etree.ElementTree as ET
 import boto3
 import pytest
-from moto import mock_s3
+from moto import mock_s3, mock_sts
 
 import bignbit.utils
 from bignbit.handle_big_result import (
@@ -73,9 +73,11 @@ def test_process_harmony_results_no_data():
     file_dicts = process_harmony_results(harmony_job, cmr_environment)
     assert file_dicts == []
 
+@mock_sts
 @mock_s3
 def test_generate_metadata():
     """Test generating image metadata xml end-to-end for a single image set."""
+    bignbit.utils.AWS_ACCOUNT_ID = None
     # image metadata xml will be uploaded within the function, so the bucket needs to be mocked
     s3_client = boto3.client('s3', region_name='us-west-2')
     bucket_name = 'svc-bignbit-podaac-sit-svc-staging'
@@ -234,9 +236,11 @@ def test_get_mdxml_cnm_file_meta():
     assert result['size'] == len(image_metadata_xml)
 
 
+@mock_sts
 @mock_s3
 def test_write_cnm_message():
     """Test writing CNM message to S3"""
+    bignbit.utils.AWS_ACCOUNT_ID = None
     # Create mock S3 bucket
     s3_client = boto3.client('s3', region_name='us-west-2')
     bucket_name = 'test-audit-bucket'

--- a/tests/test_handle_big_result.py
+++ b/tests/test_handle_big_result.py
@@ -18,9 +18,11 @@ from bignbit.handle_big_result import (
 from bignbit.image_set import ImageSet
 
 @pytest.mark.vcr
+@mock_sts
 @mock_s3
 def test_process_harmony_results():
     """Test pulling results of a harmony job from s3."""
+    bignbit.utils.AWS_ACCOUNT_ID = None
     bignbit.utils.ED_USER = 'test'
     bignbit.utils.ED_PASS = 'test'
     job_id = '3d276f84-56e2-4f0a-acb2-35b9fcaaa317'

--- a/tests/test_send_to_gitc.py
+++ b/tests/test_send_to_gitc.py
@@ -5,9 +5,10 @@ import os
 
 import boto3
 import pytest
-from moto import mock_s3, mock_sqs
+from moto import mock_s3, mock_sqs, mock_sts
 
 import bignbit.send_to_gitc
+import bignbit.utils
 
 
 @pytest.fixture
@@ -27,9 +28,11 @@ def sample_cnm_string(sample_cnm_message):
     return json.dumps(sample_cnm_message)
 
 
+@mock_sts
 @mock_s3
 def test_read_cnm(sample_cnm_string):
     """Test that read_cnm correctly reads and decodes S3 object"""
+    bignbit.utils.AWS_ACCOUNT_ID = None
     # Setup
     bucket_name = 'test-bucket'
     cnm_key = 'test-cnm-message.json'
@@ -118,10 +121,12 @@ def test_notify_gitc(sample_cnm_string):
         del os.environ['GIBS_REGION']
 
 
+@mock_sts
 @mock_s3
 @mock_sqs
 def test_notify_gitc_process_integration(sample_cnm_message, sample_cnm_string):
     """Test the full NotifyGitc.process() flow"""
+    bignbit.utils.AWS_ACCOUNT_ID = None
     # Setup S3
     bucket_name = 'test-internal-bucket'
     cnm_key = 'bignbit-cnm-output/tempo_no2_l3/test-granule.cnm.json'
@@ -183,9 +188,11 @@ def test_notify_gitc_process_integration(sample_cnm_message, sample_cnm_string):
         del os.environ['GIBS_REGION']
 
 
+@mock_sts
 @mock_s3
 def test_read_cnm_nonexistent_object():
     """Test that read_cnm raises error for nonexistent S3 object"""
+    bignbit.utils.AWS_ACCOUNT_ID = None
     # Setup
     bucket_name = 'test-bucket'
     s3_client = boto3.client('s3', region_name='us-east-1')


### PR DESCRIPTION
Github Issue: #151 

### Description

Pretty straightforward, because we use the `destination_url` parameter in our Harmony requests, we always expect the bucket owner of all of our S3 transactions in bignbit to be our own account. We can use STS to get our own account id and set that as the `ExpectedBucketOwner` for S3 upload and download.

### Overview of work done

* Added a function to get the account ID of the deployed bignbit user
* Use that account ID as the `ExpectedBucketOwner` for S3 requests
* Updated unit tests

### Overview of verification done

* Unit tests are passing
* Tested in SIT, no issues with S3 upload or download

### Overview of integration done

Integration testing N/A, this will be integration tested with a release candidate and a UAT deployment to ensure it works outside of a SIT deployment. No issues are expected when moving from SIT to UAT.

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing (N/A)

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_