### PR TITLE
Updated HarmonyTransientError handling to address reviewer comments

### DIFF
--- a/bignbit/get_harmony_job_status.py
+++ b/bignbit/get_harmony_job_status.py
@@ -108,6 +108,10 @@ def check_harmony_job(
     harmony_client = utils.get_harmony_client(cmr_env)
     try:
         job_status = harmony_client.status(harmony_job_id)
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+        raise HarmonyTransientError(
+            f'Harmony API returned a transient error checking status of job {harmony_job_id}: {exc}'
+        ) from exc
     except requests.exceptions.HTTPError as exc:
         if exc.response is not None and exc.response.status_code >= 500:
             raise HarmonyTransientError(
@@ -120,6 +124,10 @@ def check_harmony_job(
         # Check that the harmony job returned data to confirm that the job was successful
         try:
             result_urls = list(harmony_client.result_urls(harmony_job_id, link_type=LinkType.s3))
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+            raise HarmonyTransientError(
+                f'Harmony API returned a transient error fetching result URLs for job {harmony_job_id}: {exc}'
+            ) from exc
         except requests.exceptions.HTTPError as exc:
             if exc.response is not None and exc.response.status_code >= 500:
                 raise HarmonyTransientError(

--- a/terraform/state_machine_definition.tpl
+++ b/terraform/state_machine_definition.tpl
@@ -331,20 +331,13 @@
                     "Retry":[
                       {
                         "ErrorEquals":[
-                          "HarmonyJobIncompleteError"
+                          "HarmonyJobIncompleteError",
+                          "HarmonyTransientError"
                         ],
                         "IntervalSeconds":${HarmonyJobStatusIntervalSeconds},
                         "MaxAttempts":${HarmonyJobStatusMaxAttempts},
                         "BackoffRate":${HarmonyJobStatusBackoffRate},
                         "MaxDelaySeconds":${HarmonyJobStatusMaxDelaySeconds}
-                      },
-                      {
-                        "ErrorEquals":[
-                          "HarmonyTransientError"
-                        ],
-                        "IntervalSeconds":2,
-                        "MaxAttempts":6,
-                        "BackoffRate":2
                       },
                       {
                         "ErrorEquals":[


### PR DESCRIPTION
### Description

Addresses Andrew Johnston's comments on the release/0.8.0 PR.

### Overview of work done

- HarmonyTransientError is handled in the same retry logic as HarmonyJobIncompleteError in the state machine definition file
- ConnectionErrors and Timeouts when checking job status are also treated as HarmonyTransientError

### Overview of verification done

No need to update unit tests or changelog since this is part of issue 181 in the original PR.